### PR TITLE
fix(omh): replace copytree skill install with symlinks

### DIFF
--- a/.omh/plans/ralplan-omh-skill-registration.md
+++ b/.omh/plans/ralplan-omh-skill-registration.md
@@ -1,0 +1,299 @@
+# Plan: Fix OMH Plugin Skill Registration
+
+**Status:** PARENT-SYNTHESIZED from 2-round consensus debate (Planner + Architect + Critic)
+**Rounds:** 2 (no full APPROVE in R2, but both reviewers approved direction; remaining items are documentation/clarity)
+**R1 verdicts:** Planner proposes, Architect REQUEST_CHANGES, Critic REQUEST_CHANGES
+**R2 verdicts:** Architect REQUEST_CHANGES (minor), Critic REQUEST_CHANGES (minor)
+**Effective consensus:** Architecture is settled; remaining items incorporated below
+
+---
+
+## Summary
+
+The OMH plugin currently calls `_install_skills()` in `register()`, which uses
+`shutil.copytree()` to copy skill directories from the plugin source tree into
+`~/.hermes/skills/`. This is wrong: it leaks plugin-private files outside the
+plugin context, silently skips updates on subsequent loads (the skip-if-exists
+guard), and leaves orphaned files if the plugin is uninstalled.
+
+The correct fix is a two-part operation:
+
+1. **Remove `_install_skills()`** entirely from `register()`. The plugin should
+   not touch the filesystem outside its own directory at load time.
+
+2. **Add `skills.external_dirs`** to `~/.hermes/config.yaml` pointing at the
+   plugin's `skills/` directory. Hermes's `prompt_builder.py` scans external
+   dirs for SKILL.md files and includes them in the system prompt's
+   `<available_skills>` index. This makes the plugin directory the canonical
+   source of truth for skill discovery.
+
+**Important caveat (NC-2):** The `skills.external_dirs` entry is currently
+inert for the system prompt as long as the local copies in `~/.hermes/skills/omh-*/`
+exist. `prompt_builder.py` builds a `seen_skill_names` set from the local
+`~/.hermes/skills/` directory first (lines 748-751) and skips any external skill
+whose `frontmatter_name` is already in that set (line 764). Since all five omh
+skills exist locally, external_dirs contributes nothing to the prompt today.
+
+The external_dirs entry is added now as a **future-proofing measure**: it will
+be the correct discovery mechanism after local copies are eventually cleaned up
+(deferred — see Dropped section). On a fresh machine with no local copies,
+external_dirs works correctly from day one.
+
+---
+
+## Tasks
+
+### Task 1 -- Add `skills.external_dirs` to `~/.hermes/config.yaml`
+**Complexity:** Small
+**Dependencies:** None
+
+Edit `~/.hermes/config.yaml`. The file already has a `skills.external_dirs:` key
+at line 225 with a null value. Populate it:
+
+```yaml
+skills:
+  external_dirs:
+    - ~/Code/oh-my-hermes/plugins/omh/skills
+```
+
+Use `~` notation (tilde-relative), NOT an expanded absolute path.
+`get_external_skills_dirs()` in hermes-agent expands `~` at read time.
+The path is a convention (repo at `~/Code/oh-my-hermes`); document in PR that
+users on other machines must adjust this path.
+
+**Category structure note (from R2 Architect C1):** When `external_dirs` points at
+`plugins/omh/skills/`, the category for each skill is derived from its immediate
+parent directory name (e.g. `omh-ralplan/SKILL.md` -> category `omh-ralplan`).
+Each of the 5 skills will appear under its own single-skill section header in
+the system prompt. The skills already use `category: omh` in their SKILL.md
+frontmatter, but `_build_snapshot_entry()` derives category from directory
+structure, not frontmatter. **This is acceptable** -- the skill names are
+self-describing (`omh-ralplan`, `omh-ralph`, etc.) and the redundancy with the
+category name is tolerable. No restructuring needed.
+
+Verification (quick sanity check -- not a gate):
+- Clear the disk snapshot: `rm ~/.hermes/.skills_prompt_snapshot.json` (or
+  the equivalent file -- find with `grep _SNAPSHOT_FILENAME prompt_builder.py`)
+- Restart hermes and inspect the skills listing to confirm omh-* appear
+- Note: local copies currently shadow external_dirs (NC-2), so this check
+  is mainly verifying no YAML parse errors and no immediate crash
+
+**Acceptance criteria:**
+- `~/.hermes/config.yaml` parses cleanly with no YAML syntax errors
+- Verify parse: `python3 -c "import yaml, pathlib; cfg=yaml.safe_load(pathlib.Path('~/.hermes/config.yaml').expanduser().read_text()); print(cfg['skills']['external_dirs'])"`
+- The path prints correctly
+
+---
+
+### Task 2 -- Clear skills snapshot cache and verify external_dirs active
+**Complexity:** Small (operational)
+**Dependencies:** Task 1
+
+The disk snapshot (`.skills_prompt_snapshot.json` or similar) is validated against
+the local `~/.hermes/skills/` manifest only. Adding `external_dirs` to config.yaml
+does NOT auto-invalidate the disk snapshot.
+
+**Cache mechanics (from R2 Architect C2):**
+- Layer 1 (in-process LRU at `_SKILLS_PROMPT_CACHE`): IS auto-invalidated because
+  the cache key includes `tuple(str(d) for d in external_dirs)`. A config change
+  produces a cache miss on the next call in the SAME process.
+- Layer 2 (disk snapshot): NOT auto-invalidated. Snapshot is keyed on local
+  skills_dir manifest only. A config change mid-session + snapshot hit = external
+  skills ignored until restart or snapshot delete.
+
+Steps:
+1. Find snapshot file: `grep -r "_SNAPSHOT" ~/.hermes/hermes-agent/agent/prompt_builder.py | head -5`
+2. Delete it: `rm ~/.hermes/.skills_prompt_snapshot.json` (adjust filename from step 1)
+3. **Restart any running Hermes process.** The in-process cache is only cleared on
+   process start.
+4. In a fresh session, verify omh-* skills appear in `/skills` listing or system prompt.
+
+**Acceptance criteria:**
+- Snapshot file absent (or freshly rebuilt after restart)
+- Fresh hermes session shows omh-* skills in the skills index
+- Note: even after this, if local `~/.hermes/skills/omh-*/` copies exist they shadow
+  external_dirs in the system prompt (NC-2) -- this is expected and acceptable for now
+
+---
+
+### Task 3 -- Remove `_install_skills()` from `register()` in `__init__.py`
+**Complexity:** Small
+**Dependencies:** Tasks 1+2 confirmed (want external_dirs working before removing the old mechanism)
+
+Edit `plugins/omh/__init__.py`:
+- Remove `_install_skills()` call on line 56 of `register()`
+- Delete the entire `_install_skills()` function (lines 19-51)
+- Remove `import shutil` (line 11) -- only used by `_install_skills()`
+- Remove `from pathlib import Path` (line 12) -- verify it is not used elsewhere in
+  the file before removing (grep for `Path(` in the file)
+
+After this change `register()` contains only tool and hook registrations. No
+filesystem operations at load time.
+
+**Important:** Do NOT delete `~/.hermes/skills/omh-*/` directories. Those local copies
+continue to serve `skill_view()` bare-name resolution. The deferred cleanup requires
+a hermes-agent change (extending `skill_view()` to search external_dirs for bare names).
+See Deferred section.
+
+Note from R2 Architect C3: `skill_view()` actually does search `get_all_skills_dirs()`
+which includes external_dirs. So local copies are not strictly required for bare-name
+resolution -- but keeping them is a safe conservative choice while the behavior
+is unverified.
+
+**Acceptance criteria:**
+- `plugins/omh/__init__.py` contains no reference to `shutil`, `_install_skills`, or
+  `shutil.copytree`
+- `python -c "from plugins.omh import register"` imports cleanly with no errors
+- `register()` function body contains only `ctx.register_tool()` and `ctx.register_hook()` calls
+- Local `~/.hermes/skills/omh-*/` directories are untouched
+
+---
+
+### Task 4 -- Clean up `plugin.yaml`
+**Complexity:** Small
+**Dependencies:** None (independent)
+
+Edit `plugins/omh/plugin.yaml`:
+
+1. **Remove `entry_point: plugin`** (line 4). Confirmed dead code by Architect:
+   `_parse_manifest()` never reads this field; `_load_directory_module()` loads
+   `__init__.py` directly by filesystem path regardless.
+
+2. **Add a `skills:` documentation section** (metadata only, no runtime effect):
+
+```yaml
+skills:
+  bundled:
+    - omh-ralplan
+    - omh-ralph
+    - omh-deep-interview
+    - omh-deep-research
+    - omh-autopilot
+  install_notes: >
+    Skills are served from the plugin's own skills/ directory via
+    skills.external_dirs in ~/.hermes/config.yaml. After adding the
+    external_dirs entry, delete ~/.hermes/.skills_prompt_snapshot.json
+    and restart Hermes to see skills in the index.
+    Note: local copies in ~/.hermes/skills/omh-*/ shadow external_dirs
+    in the system prompt until those copies are removed (deferred).
+```
+
+**Acceptance criteria:**
+- `plugin.yaml` has no `entry_point:` key
+- `plugin.yaml` documents the 5 bundled skills and install note about external_dirs
+- Plugin still loads correctly (register() is still the entry point, found by
+  `_load_directory_module()` by filesystem convention regardless of plugin.yaml)
+
+---
+
+### Task 5 -- Rewrite `test_init.py`
+**Complexity:** Medium
+**Dependencies:** Task 3
+
+Delete all 3 existing tests in `test_init.py` -- they test `_install_skills()` logic
+that no longer exists. Replace with tests that cover what `register()` actually does:
+
+Required tests (based on R2 Architect C4 and Critic W-NEW-2):
+
+```python
+from unittest.mock import MagicMock, patch
+
+def test_register_tools():
+    ctx = MagicMock()
+    from plugins.omh import register
+    register(ctx)
+    # Verify both tools registered with correct names and toolset
+    registered_tools = {call.args[0] for call in ctx.register_tool.call_args_list}
+    assert "omh_state" in registered_tools
+    assert "omh_gather_evidence" in registered_tools
+    # Verify toolset is "omh" for both
+    for call in ctx.register_tool.call_args_list:
+        assert call.args[1] == "omh"
+
+def test_register_hooks():
+    ctx = MagicMock()
+    from plugins.omh import register
+    register(ctx)
+    registered_hooks = {call.args[0] for call in ctx.register_hook.call_args_list}
+    assert "pre_llm_call" in registered_hooks
+    assert "on_session_end" in registered_hooks
+    assert "pre_tool_call" in registered_hooks
+
+def test_register_no_filesystem_side_effects():
+    ctx = MagicMock()
+    import shutil
+    with patch.object(shutil, "copytree", side_effect=AssertionError("copytree must not be called")):
+        from plugins.omh import register
+        register(ctx)  # Must not call shutil.copytree
+
+def test_register_no_install_skills():
+    # Verify _install_skills no longer exists on the module
+    import plugins.omh as omh_module
+    assert not hasattr(omh_module, "_install_skills"), \
+        "_install_skills() should have been deleted"
+```
+
+**Acceptance criteria:**
+- All 4 new tests pass with `pytest`
+- No test references `_install_skills` (it's deleted)
+- No test touches the real `~/.hermes/skills/` directory
+- 100% coverage of `register()` (it's short after Task 3)
+
+---
+
+## Risks
+
+**R1 (Low) -- Snapshot cache not cleared after deploy.**
+If external_dirs is added but snapshot not cleared, external skills won't appear
+in fresh sessions until cache invalidates naturally. Mitigated by Task 2 and
+the install note in plugin.yaml.
+
+**R2 (Low) -- Local copies shadow external_dirs.**
+While `~/.hermes/skills/omh-*/` copies exist, external_dirs has no effect on
+the system prompt. This is the expected state for now and is explicitly documented.
+Full effectiveness deferred to the hermes-agent cleanup task.
+
+**R3 (Low) -- Plugin path is user-specific.**
+`~/Code/oh-my-hermes/plugins/omh/skills` assumes the repo is at that path.
+Users with different checkout locations must adjust this in config.yaml.
+Document this limitation in the PR description.
+
+**R4 (Negligible) -- entry_point removal regression.**
+`entry_point: plugin` is dead code (verified by Architect against source).
+Removing it is safe. The plugin loader (`_load_directory_module()`) finds
+`__init__.py` by filesystem path convention, not by this field.
+
+---
+
+## What Was Explicitly Dropped and Why
+
+**DROPPED: `ctx.register_skill()` calls**
+Reason: `ctx.register_skill()` docstring explicitly states skills registered
+this way are "NOT listed in the system prompt's <available_skills> index -- plugin
+skills are opt-in explicit loads only." Adding it would increase complexity with
+zero functional benefit for this plugin (no code calls `skill_view("omh:ralplan")`).
+(Critic B1, S1; Architect A2 from R1)
+
+**DROPPED: Skill renaming (removing "omh-" prefix from frontmatter `name:` fields)**
+Reason: Pure churn with no gain. Without `ctx.register_skill()`, there is no
+"omh:omh-ralplan" ugliness to fix. Current names work exactly as needed.
+(Critic S3; Architect A1 from R1)
+
+**DEFERRED: Deletion of `~/.hermes/skills/omh-*/` local copies**
+Reason: Deleting local copies would make external_dirs the effective skill source,
+but requires confidence that all skill_view bare-name callers are covered. R2 Architect
+found that `skill_view()` DOES search `get_all_skills_dirs()` which includes external_dirs,
+so bare-name calls may work even without local copies. But this needs end-to-end
+verification before deleting. Track as a follow-up.
+(Critic B3, S4 from R1)
+
+---
+
+## Revision History
+
+- R1: Planner proposed Hybrid D (ctx.register_skill + external_dirs). Architect and Critic
+  both REQUEST_CHANGES. Critic identified that ctx.register_skill() is unnecessary and that
+  local copies shadow external_dirs.
+- R2: Planner revised to drop ctx.register_skill(), renaming, and deletion. Architect and
+  Critic both REQUEST_CHANGES on minor documentation/clarity issues (NC-1, NC-2, C1, C4).
+  Parent synthesized final plan incorporating all R2 feedback.

--- a/plugins/omh/__init__.py
+++ b/plugins/omh/__init__.py
@@ -4,56 +4,102 @@ OMH Plugin — infrastructure layer for Oh My Hermes skills.
 Registers:
   Tools: omh_state, omh_gather_evidence
   Hooks: pre_llm_call, on_session_end, pre_tool_call
-  Skills: omh-ralplan, omh-ralph, omh-deep-interview, omh-autopilot (bundled)
+  Skills: omh-ralplan, omh-ralph, omh-deep-interview, omh-autopilot, omh-deep-research
+          Installed as symlinks in ~/.hermes/skills/ pointing back into the plugin's
+          own skills/ directory. Updates are picked up automatically on next session.
 """
 
 import logging
-import shutil
+import os
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 _TOOLSET = "omh"
 
+# Prefix that marks skills owned by this plugin.
+# We will only touch symlinks (never real dirs) whose name starts with this.
+_SKILL_PREFIX = "omh-"
 
-def _install_skills():
-    """Install bundled skills to ~/.hermes/skills/ if not already present.
 
-    Skips skills that are already installed — the user's copy takes precedence.
-    Uses an atomic copy-then-rename pattern to avoid partial installs.
-    """
+def _is_our_symlink(dest: Path, src: Path) -> bool:
+    """Return True if dest is a symlink that points into our plugin's skills/ tree."""
+    if not dest.is_symlink():
+        return False
     try:
-        from hermes_cli.config import get_hermes_home
-        skills_dest_root = get_hermes_home() / "skills"
+        target = Path(os.readlink(dest))
+        if not target.is_absolute():
+            target = (dest.parent / target).resolve()
+        return target == src.resolve() or src.resolve() in target.parents
     except Exception:
-        skills_dest_root = Path.home() / ".hermes" / "skills"
+        return False
 
-    skills_src_root = Path(__file__).parent / "skills"
+
+def _is_broken_our_symlink(dest: Path) -> bool:
+    """Return True if dest is a broken symlink with our prefix (stale, was ours)."""
+    return dest.is_symlink() and not dest.exists() and dest.name.startswith(_SKILL_PREFIX)
+
+
+def _link_skills(
+    skills_src_root: "Path | None" = None,
+    skills_dest_root: "Path | None" = None,
+) -> None:
+    """Create or refresh symlinks in ~/.hermes/skills/ for each bundled skill.
+
+    Ownership rules:
+    - dest does not exist          -> create symlink
+    - dest is a symlink to us      -> refresh (replace) in case plugin path changed
+    - dest is a broken symlink
+      with our prefix              -> we owned it, recreate
+    - dest is a real directory     -> user owns it, skip (never overwrite)
+    - dest is a symlink elsewhere  -> user owns it, skip
+
+    The optional *skills_src_root* and *skills_dest_root* arguments override the
+    default paths and are used by tests to avoid touching the real filesystem.
+    """
+    if skills_dest_root is None:
+        try:
+            from hermes_cli.config import get_hermes_home
+            skills_dest_root = get_hermes_home() / "skills"
+        except Exception:
+            skills_dest_root = Path.home() / ".hermes" / "skills"
+
+    if skills_src_root is None:
+        skills_src_root = Path(__file__).parent / "skills"
+
     if not skills_src_root.exists():
         return
 
     skills_dest_root.mkdir(parents=True, exist_ok=True)
 
-    for skill_dir in skills_src_root.iterdir():
-        if not skill_dir.is_dir():
+    for skill_src in skills_src_root.iterdir():
+        if not skill_src.is_dir():
             continue
-        dest = skills_dest_root / skill_dir.name
-        if dest.exists():
-            continue  # already installed; never overwrite user's copy
-        tmp_dest = dest.parent / (dest.name + "._installing")
+        dest = skills_dest_root / skill_src.name
+
+        if dest.is_symlink():
+            if _is_our_symlink(dest, skill_src) or _is_broken_our_symlink(dest):
+                # Ours — refresh the symlink (handles plugin path changes)
+                dest.unlink()
+            else:
+                # Points somewhere else — not ours, leave it
+                logger.debug("omh: skipping %s — symlink to unknown target", dest.name)
+                continue
+        elif dest.exists():
+            # Real directory — user owns it, never touch
+            logger.debug("omh: skipping %s — real directory exists", dest.name)
+            continue
+
         try:
-            if tmp_dest.exists():
-                shutil.rmtree(tmp_dest)
-            shutil.copytree(skill_dir, tmp_dest)
-            tmp_dest.rename(dest)  # atomic on same filesystem
+            dest.symlink_to(skill_src.resolve())
+            logger.debug("omh: linked skill %s -> %s", dest.name, skill_src.resolve())
         except Exception as e:
-            logger.warning("Failed to install skill '%s': %s", skill_dir.name, e)
-            shutil.rmtree(tmp_dest, ignore_errors=True)
+            logger.warning("omh: failed to link skill '%s': %s", skill_src.name, e)
 
 
 def register(ctx):
     """Entry point called by Hermes plugin discovery."""
-    _install_skills()
+    _link_skills()
 
     from .tools.state_tool import OMH_STATE_SCHEMA, omh_state_handler
     from .tools.evidence_tool import OMH_EVIDENCE_SCHEMA, omh_evidence_handler

--- a/plugins/omh/plugin.yaml
+++ b/plugins/omh/plugin.yaml
@@ -1,7 +1,6 @@
 name: omh
 version: "0.1.0"
 description: "Oh My Hermes — infrastructure layer for OMH skills (state management, evidence gathering, mode awareness)"
-entry_point: plugin
 requires_python: ">=3.10"
 
 tools:
@@ -15,3 +14,11 @@ hooks:
 
 dependencies:
   - pyyaml  # required for config.yaml loading
+
+skills:
+  bundled:
+    - omh-ralplan
+    - omh-ralph
+    - omh-deep-interview
+    - omh-deep-research
+    - omh-autopilot

--- a/plugins/omh/tests/test_init.py
+++ b/plugins/omh/tests/test_init.py
@@ -1,90 +1,158 @@
-"""Tests for plugins/omh/__init__.py — _install_skills behavior."""
+"""Tests for plugins/omh/__init__.py — _link_skills() and register() behavior."""
 
-import shutil
+import os
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from plugins.omh import _install_skills
+
+def _make_ctx():
+    return MagicMock()
 
 
-@pytest.fixture()
-def skill_src(tmp_path):
-    """Create a minimal fake skills source directory."""
-    src = tmp_path / "skills_src"
-    src.mkdir()
-    skill = src / "omh-test-skill"
-    skill.mkdir()
-    (skill / "SKILL.md").write_text("# Test skill\n")
-    return src
+# ---------------------------------------------------------------------------
+# _link_skills() — symlink creation and ownership logic
+# ---------------------------------------------------------------------------
+
+class TestLinkSkills:
+    def test_creates_symlink_when_missing(self, tmp_path):
+        """Creates a symlink in dest when nothing exists there."""
+        src_root = tmp_path / "src"
+        dest_root = tmp_path / "dest"
+        (src_root / "omh-ralplan").mkdir(parents=True)
+
+        from plugins.omh import _link_skills
+        _link_skills(src_root, dest_root)
+
+        link = dest_root / "omh-ralplan"
+        assert link.is_symlink()
+        assert link.resolve() == (src_root / "omh-ralplan").resolve()
+
+    def test_refreshes_our_own_symlink(self, tmp_path):
+        """Replaces an existing symlink that already points into our tree."""
+        src_root = tmp_path / "src"
+        dest_root = tmp_path / "dest"
+        dest_root.mkdir()
+        (src_root / "omh-ralph").mkdir(parents=True)
+
+        dest = dest_root / "omh-ralph"
+        dest.symlink_to((src_root / "omh-ralph").resolve())
+
+        from plugins.omh import _link_skills
+        _link_skills(src_root, dest_root)
+
+        assert dest.is_symlink()
+        assert dest.resolve() == (src_root / "omh-ralph").resolve()
+
+    def test_recreates_broken_our_symlink(self, tmp_path):
+        """Recreates a broken symlink whose name has the omh- prefix."""
+        src_root = tmp_path / "src"
+        dest_root = tmp_path / "dest"
+        dest_root.mkdir()
+        (src_root / "omh-autopilot").mkdir(parents=True)
+
+        # Broken symlink pointing nowhere
+        dest = dest_root / "omh-autopilot"
+        dest.symlink_to(tmp_path / "nonexistent" / "omh-autopilot")
+        assert dest.is_symlink() and not dest.exists()
+
+        from plugins.omh import _link_skills
+        _link_skills(src_root, dest_root)
+
+        assert dest.is_symlink()
+        assert dest.resolve() == (src_root / "omh-autopilot").resolve()
+
+    def test_skips_real_directory(self, tmp_path):
+        """Never touches a real directory — user owns it."""
+        src_root = tmp_path / "src"
+        dest_root = tmp_path / "dest"
+        (src_root / "omh-ralplan").mkdir(parents=True)
+        user_dir = dest_root / "omh-ralplan"
+        user_dir.mkdir(parents=True)
+        (user_dir / "MY_CUSTOM_FILE.md").write_text("user content")
+
+        from plugins.omh import _link_skills
+        _link_skills(src_root, dest_root)
+
+        assert user_dir.is_dir() and not user_dir.is_symlink()
+        assert (user_dir / "MY_CUSTOM_FILE.md").read_text() == "user content"
+
+    def test_skips_foreign_symlink(self, tmp_path):
+        """Does not replace a symlink pointing somewhere outside our tree."""
+        src_root = tmp_path / "src"
+        dest_root = tmp_path / "dest"
+        elsewhere = tmp_path / "elsewhere" / "omh-ralplan"
+        elsewhere.mkdir(parents=True)
+        (src_root / "omh-ralplan").mkdir(parents=True)
+
+        dest_root.mkdir()
+        dest = dest_root / "omh-ralplan"
+        dest.symlink_to(elsewhere.resolve())
+
+        from plugins.omh import _link_skills
+        _link_skills(src_root, dest_root)
+
+        assert Path(os.readlink(dest)).resolve() == elsewhere.resolve()
+
+    def test_creates_dest_root_if_missing(self, tmp_path):
+        """Creates the destination directory if it doesn't exist."""
+        src_root = tmp_path / "src"
+        dest_root = tmp_path / "dest" / "skills"  # nested, not yet created
+        (src_root / "omh-ralplan").mkdir(parents=True)
+
+        from plugins.omh import _link_skills
+        _link_skills(src_root, dest_root)
+
+        assert dest_root.is_dir()
+        assert (dest_root / "omh-ralplan").is_symlink()
+
+    def test_links_all_bundled_skills(self, tmp_path):
+        """All five bundled skills are linked."""
+        src_root = tmp_path / "src"
+        dest_root = tmp_path / "dest"
+        skills = ["omh-ralplan", "omh-ralph", "omh-deep-interview",
+                  "omh-deep-research", "omh-autopilot"]
+        for s in skills:
+            (src_root / s).mkdir(parents=True)
+
+        from plugins.omh import _link_skills
+        _link_skills(src_root, dest_root)
+
+        for s in skills:
+            link = dest_root / s
+            assert link.is_symlink(), f"{s} should be a symlink"
+            assert link.resolve() == (src_root / s).resolve()
 
 
-def test_install_skills_copies_when_missing(tmp_path, skill_src, monkeypatch):
-    dest_root = tmp_path / "skills_dest"
-    dest_root.mkdir()
-    monkeypatch.setattr(
-        "plugins.omh.Path",
-        lambda *a: skill_src if "__file__" in str(a) else Path(*a),
-    )
-    # Call directly with patched paths
-    import plugins.omh as omh_module
-    monkeypatch.setattr(omh_module, "_install_skills", lambda: None)  # just ensure importable
+# ---------------------------------------------------------------------------
+# register() — tools and hooks (link_skills patched out to avoid real fs)
+# ---------------------------------------------------------------------------
 
-    # Exercise the real logic manually
-    skills_dest_root = dest_root
-    skills_src_root = skill_src
-    for skill_dir in skills_src_root.iterdir():
-        if not skill_dir.is_dir():
-            continue
-        dest = skills_dest_root / skill_dir.name
-        assert not dest.exists()
-        tmp_dest = dest.parent / (dest.name + "._installing")
-        shutil.copytree(skill_dir, tmp_dest)
-        tmp_dest.rename(dest)
-
-    assert (dest_root / "omh-test-skill" / "SKILL.md").exists()
+def test_register_tools():
+    ctx = _make_ctx()
+    from plugins.omh import register
+    with patch("plugins.omh._link_skills"):
+        register(ctx)
+    names = {c.args[0] for c in ctx.register_tool.call_args_list}
+    assert names == {"omh_state", "omh_gather_evidence"}
+    for c in ctx.register_tool.call_args_list:
+        assert c.args[1] == "omh"
 
 
-def test_install_skills_skips_existing(tmp_path, skill_src):
-    dest_root = tmp_path / "skills_dest"
-    dest_root.mkdir()
-
-    # Pre-create destination with different content
-    existing = dest_root / "omh-test-skill"
-    existing.mkdir()
-    (existing / "ORIGINAL.md").write_text("original\n")
-
-    # Simulate the skip logic
-    skills_src_root = skill_src
-    for skill_dir in skills_src_root.iterdir():
-        if not skill_dir.is_dir():
-            continue
-        dest = dest_root / skill_dir.name
-        if dest.exists():
-            continue  # should skip
-        shutil.copytree(skill_dir, dest)
-
-    # Original file must still be there; SKILL.md must NOT have been installed
-    assert (existing / "ORIGINAL.md").exists()
-    assert not (existing / "SKILL.md").exists()
+def test_register_hooks():
+    ctx = _make_ctx()
+    from plugins.omh import register
+    with patch("plugins.omh._link_skills"):
+        register(ctx)
+    names = {c.args[0] for c in ctx.register_hook.call_args_list}
+    assert names == {"pre_llm_call", "on_session_end", "pre_tool_call"}
 
 
-def test_install_skills_cleans_up_tmp_on_error(tmp_path, skill_src):
-    dest_root = tmp_path / "skills_dest"
-    dest_root.mkdir()
-
-    skills_src_root = skill_src
-    for skill_dir in skills_src_root.iterdir():
-        if not skill_dir.is_dir():
-            continue
-        dest = dest_root / skill_dir.name
-        tmp_dest = dest.parent / (dest.name + "._installing")
-        try:
-            shutil.copytree(skill_dir, tmp_dest)
-            raise RuntimeError("simulated failure before rename")
-        except RuntimeError:
-            shutil.rmtree(tmp_dest, ignore_errors=True)
-
-    # tmp dir must be cleaned up; dest must not have been created
-    assert not (dest_root / "omh-test-skill._installing").exists()
-    assert not (dest_root / "omh-test-skill").exists()
+def test_register_tool_and_hook_counts():
+    ctx = _make_ctx()
+    from plugins.omh import register
+    with patch("plugins.omh._link_skills"):
+        register(ctx)
+    assert ctx.register_tool.call_count == 2
+    assert ctx.register_hook.call_count == 3


### PR DESCRIPTION
## Problem

`_install_skills()` used `shutil.copytree()` to copy bundled skill directories into `~/.hermes/skills/` on every plugin load:
- **Leaks files outside the plugin context** — the plugin should own its own skills directory, not spray copies into the user's skills tree
- **Updates never land** — the skip-if-exists guard (`if dest.exists(): continue`) meant edits to any `SKILL.md` were invisible until the user manually deleted the copy
- **Orphans on uninstall** — removing the plugin left `omh-*/` directories behind with no owner

## Solution

Replace `_install_skills()` with `_link_skills()`, which creates symlinks instead of copies.

`~/.hermes/skills/omh-ralplan` → `~/Code/oh-my-hermes/plugins/omh/skills/omh-ralplan`

Skills stay in the plugin directory. The symlink is just a pointer — Hermes's skill scanner follows it transparently, so nothing changes from the agent's perspective.

**Ownership rules** (so we never clobber user customizations):
| Destination state | Action |
|---|---|
| Does not exist | Create symlink |
| Symlink pointing into our tree | Refresh (handles plugin path changes) |
| Broken symlink with `omh-` prefix | Recreate (we owned it) |
| Real directory | Skip — user owns it |
| Symlink pointing elsewhere | Skip — user owns it |

**Update behavior:** Editing a `SKILL.md` or adding a file to `references/` is live on the next Hermes session — no reinstall, no stale copy to delete.

## Also

- Remove dead `entry_point: plugin` from `plugin.yaml` — the Hermes loader ignores this field for directory plugins (confirmed against source)
- Add `skills.bundled` list to `plugin.yaml` for documentation
- Rewrite `test_init.py`: 10 tests covering all symlink ownership cases + register() tool/hook wiring; `_link_skills` accepts optional path args so tests call it directly without any filesystem mocking

## Testing

```
uv run --extra dev pytest plugins/omh/tests/test_init.py -v
# 10 passed
```