### PR TITLE
fix(omh): category grouping, frontmatter schema, and description truncation

### DIFF
--- a/plugins/omh/__init__.py
+++ b/plugins/omh/__init__.py
@@ -16,19 +16,25 @@ logger = logging.getLogger(__name__)
 _TOOLSET = "omh"
 
 
-def _install_skills():
-    """Install bundled skills to ~/.hermes/skills/ if not already present.
+def _install_skills(
+    skills_src_root: Path | None = None,
+    skills_dest_root: Path | None = None,
+) -> None:
+    """Install bundled skills to ~/.hermes/skills/omh/ if not already present.
 
     Skips skills that are already installed — the user's copy takes precedence.
     Uses an atomic copy-then-rename pattern to avoid partial installs.
     """
-    try:
-        from hermes_cli.config import get_hermes_home
-        skills_dest_root = get_hermes_home() / "skills"
-    except Exception:
-        skills_dest_root = Path.home() / ".hermes" / "skills"
+    if skills_dest_root is None:
+        try:
+            from hermes_cli.config import get_hermes_home
+            skills_dest_root = get_hermes_home() / "skills" / "omh"
+        except Exception:
+            skills_dest_root = Path.home() / ".hermes" / "skills" / "omh"
 
-    skills_src_root = Path(__file__).parent / "skills"
+    if skills_src_root is None:
+        skills_src_root = Path(__file__).parent / "skills"
+
     if not skills_src_root.exists():
         return
 

--- a/plugins/omh/skills/omh-autopilot/SKILL.md
+++ b/plugins/omh/skills/omh-autopilot/SKILL.md
@@ -5,7 +5,7 @@ version: 2.0.0
 metadata:
   hermes:
     requires_toolsets: [terminal, omh]
-    tags: [oh-my-hermes, productivity]
+    tags: [autopilot, pipeline, autonomous, end-to-end, composition]
     category: omh
 ---
 

--- a/plugins/omh/skills/omh-autopilot/SKILL.md
+++ b/plugins/omh/skills/omh-autopilot/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: omh-autopilot
-description: >
-  Full autonomous pipeline from idea to verified code. Composes deep-interview,
-  ralplan, and ralph into 6 phases: Requirements → Planning → Execution → QA →
-  Validation → Cleanup. One phase step per invocation — the caller re-invokes
-  until complete. Detects existing artifacts to skip completed phases.
+description: "Idea-to-code pipeline: interview→plan→execute→verify"
 version: 2.0.0
 metadata:
   hermes:

--- a/plugins/omh/skills/omh-autopilot/SKILL.md
+++ b/plugins/omh/skills/omh-autopilot/SKILL.md
@@ -6,11 +6,11 @@ description: >
   Validation → Cleanup. One phase step per invocation — the caller re-invokes
   until complete. Detects existing artifacts to skip completed phases.
 version: 2.0.0
-tags: [autopilot, pipeline, autonomous, end-to-end, composition]
-category: omh
 metadata:
   hermes:
     requires_toolsets: [terminal, omh]
+    tags: [oh-my-hermes, productivity]
+    category: omh
 ---
 
 # OMH Autopilot — End-to-End Autonomous Pipeline

--- a/plugins/omh/skills/omh-autopilot/SKILL.md
+++ b/plugins/omh/skills/omh-autopilot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-autopilot
-description: "Idea-to-code pipeline: interview→plan→execute→verify"
+description: "pipeline: interview→plan→execute→QA→verify (idea→code)"
 version: 2.0.0
 metadata:
   hermes:

--- a/plugins/omh/skills/omh-deep-interview/SKILL.md
+++ b/plugins/omh/skills/omh-deep-interview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-deep-interview
-description: Socratic requirements interview for vague/ambiguous goals
+description: Socratic reqs interview; clarify vague/ambiguous goals
 version: 2.0.0
 metadata:
   hermes:

--- a/plugins/omh/skills/omh-deep-interview/SKILL.md
+++ b/plugins/omh/skills/omh-deep-interview/SKILL.md
@@ -6,10 +6,10 @@ description: >
   Existing Context), tracks coverage with coarse bins, and produces a consumer-ready
   specification. Exit is always user-confirmed. Use when goals are vague or underspecified.
 version: 2.0.0
-tags: [interview, requirements, socratic, ambiguity, specification]
-category: omh
 metadata:
   hermes:
+    tags: [interview, requirements, socratic, ambiguity, specification]
+    category: omh
     requires_toolsets: [terminal, omh]
 ---
 

--- a/plugins/omh/skills/omh-deep-interview/SKILL.md
+++ b/plugins/omh/skills/omh-deep-interview/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: omh-deep-interview
-description: >
-  Socratic requirements interview that reduces ambiguity before planning or implementation.
-  Asks targeted questions across four dimensions (Goal, Constraints, Success Criteria,
-  Existing Context), tracks coverage with coarse bins, and produces a consumer-ready
-  specification. Exit is always user-confirmed. Use when goals are vague or underspecified.
+description: Socratic requirements interview for vague/ambiguous goals
 version: 2.0.0
 metadata:
   hermes:

--- a/plugins/omh/skills/omh-deep-research/SKILL.md
+++ b/plugins/omh/skills/omh-deep-research/SKILL.md
@@ -7,10 +7,10 @@ description: >
   and re-invoke to resume. Sentinel: `.omh/research/{slug}-report.md` with
   frontmatter `status: confirmed`.
 version: 1.0.0
-tags: [research, web, synthesis, parallel, omh]
-category: omh
 metadata:
   hermes:
+    tags: [research, web, synthesis, parallel, omh]
+    category: omh
     requires_toolsets: [terminal, omh, web]
 ---
 

--- a/plugins/omh/skills/omh-deep-research/SKILL.md
+++ b/plugins/omh/skills/omh-deep-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-deep-research
-description: Parallel web research with synthesis and citation checks
+description: parallel web research; subagents→synthesis→cite-verify
 version: 1.0.0
 metadata:
   hermes:

--- a/plugins/omh/skills/omh-deep-research/SKILL.md
+++ b/plugins/omh/skills/omh-deep-research/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: omh-deep-research
-description: >
-  Multi-phase web research that decomposes a topic into subtopics, dispatches
-  parallel researcher subagents, synthesizes a report, and verifies citations
-  before marking it confirmed. State is durable: kill at any phase boundary
-  and re-invoke to resume. Sentinel: `.omh/research/{slug}-report.md` with
-  frontmatter `status: confirmed`.
+description: Parallel web research with synthesis and citation checks
 version: 1.0.0
 metadata:
   hermes:

--- a/plugins/omh/skills/omh-ralph/SKILL.md
+++ b/plugins/omh/skills/omh-ralph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-ralph
-description: "Verified execution: one task/invocation, iron-law checks"
+description: "execute plan: 1 task/call, verify evidence, iron law"
 version: 2.0.0
 metadata:
   hermes:

--- a/plugins/omh/skills/omh-ralph/SKILL.md
+++ b/plugins/omh/skills/omh-ralph/SKILL.md
@@ -5,7 +5,7 @@ version: 2.0.0
 metadata:
   hermes:
     requires_toolsets: [terminal, omh]
-    tags: [oh-my-hermes, productivity]
+    tags: [execution, verification, persistence, iron-law, loop]
     category: omh
 ---
 

--- a/plugins/omh/skills/omh-ralph/SKILL.md
+++ b/plugins/omh/skills/omh-ralph/SKILL.md
@@ -6,11 +6,11 @@ description: >
   invocation — the caller re-invokes until all tasks pass. Enforces the Iron Law:
   every change must be verified through builds, tests, and independent review.
 version: 2.0.0
-tags: [execution, verification, persistence, iron-law, loop]
-category: omh
 metadata:
   hermes:
     requires_toolsets: [terminal, omh]
+    tags: [oh-my-hermes, productivity]
+    category: omh
 ---
 
 # OMH Ralph — Verified Execution (v2)

--- a/plugins/omh/skills/omh-ralph/SKILL.md
+++ b/plugins/omh/skills/omh-ralph/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: omh-ralph
-description: >
-  Verified execution loop: picks the next task from a plan, delegates to an executor
-  subagent, verifies completion with fresh evidence, and updates state. One task per
-  invocation — the caller re-invokes until all tasks pass. Enforces the Iron Law:
-  every change must be verified through builds, tests, and independent review.
+description: "Verified execution: one task/invocation, iron-law checks"
 version: 2.0.0
 metadata:
   hermes:

--- a/plugins/omh/skills/omh-ralplan/SKILL.md
+++ b/plugins/omh/skills/omh-ralplan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omh-ralplan
-description: Consensus plan via Planner+Architect+Critic debate
+description: "Planner+Architect+Critic→consensus impl plan (≤3 rounds)"
 version: 2.0.0
 metadata:
   hermes:

--- a/plugins/omh/skills/omh-ralplan/SKILL.md
+++ b/plugins/omh/skills/omh-ralplan/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: omh-ralplan
-description: >
-  Consensus planning via multi-agent debate. Three perspectives (Planner, Architect, Critic)
-  iterate until consensus or max rounds. Produces a vetted implementation plan. Use for any
-  non-trivial task where a single perspective might miss blind spots.
+description: Consensus plan via Planner+Architect+Critic debate
 version: 2.0.0
 metadata:
   hermes:

--- a/plugins/omh/skills/omh-ralplan/SKILL.md
+++ b/plugins/omh/skills/omh-ralplan/SKILL.md
@@ -5,10 +5,10 @@ description: >
   iterate until consensus or max rounds. Produces a vetted implementation plan. Use for any
   non-trivial task where a single perspective might miss blind spots.
 version: 2.0.0
-tags: [planning, multi-agent, consensus, architecture]
-category: omh
 metadata:
   hermes:
+    tags: [planning, multi-agent, consensus, architecture]
+    category: omh
     requires_toolsets: [terminal, omh]
 ---
 

--- a/plugins/omh/tests/test_init.py
+++ b/plugins/omh/tests/test_init.py
@@ -1,7 +1,6 @@
 """Tests for plugins/omh/__init__.py — _install_skills behavior."""
 
 import shutil
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -50,7 +49,7 @@ def test_install_skills_cleans_up_tmp_on_error(tmp_path, skill_src):
     dest_root = tmp_path / "skills_dest"
     dest_root.mkdir()
 
-    # Make copytree fail by making the tmp_dest unwritable after creation
+    # Simulate copytree failing after populating tmp_dest, before rename/atomic install completes
     original_copytree = shutil.copytree
 
     def fail_copytree(src, dst, **kwargs):

--- a/plugins/omh/tests/test_init.py
+++ b/plugins/omh/tests/test_init.py
@@ -2,6 +2,7 @@
 
 import shutil
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -19,30 +20,14 @@ def skill_src(tmp_path):
     return src
 
 
-def test_install_skills_copies_when_missing(tmp_path, skill_src, monkeypatch):
+def test_install_skills_copies_when_missing(tmp_path, skill_src):
     dest_root = tmp_path / "skills_dest"
     dest_root.mkdir()
-    monkeypatch.setattr(
-        "plugins.omh.Path",
-        lambda *a: skill_src if "__file__" in str(a) else Path(*a),
-    )
-    # Call directly with patched paths
-    import plugins.omh as omh_module
-    monkeypatch.setattr(omh_module, "_install_skills", lambda: None)  # just ensure importable
 
-    # Exercise the real logic manually
-    skills_dest_root = dest_root
-    skills_src_root = skill_src
-    for skill_dir in skills_src_root.iterdir():
-        if not skill_dir.is_dir():
-            continue
-        dest = skills_dest_root / skill_dir.name
-        assert not dest.exists()
-        tmp_dest = dest.parent / (dest.name + "._installing")
-        shutil.copytree(skill_dir, tmp_dest)
-        tmp_dest.rename(dest)
+    _install_skills(skill_src, dest_root)
 
     assert (dest_root / "omh-test-skill" / "SKILL.md").exists()
+    assert (dest_root / "omh-test-skill" / "SKILL.md").read_text() == "# Test skill\n"
 
 
 def test_install_skills_skips_existing(tmp_path, skill_src):
@@ -54,15 +39,7 @@ def test_install_skills_skips_existing(tmp_path, skill_src):
     existing.mkdir()
     (existing / "ORIGINAL.md").write_text("original\n")
 
-    # Simulate the skip logic
-    skills_src_root = skill_src
-    for skill_dir in skills_src_root.iterdir():
-        if not skill_dir.is_dir():
-            continue
-        dest = dest_root / skill_dir.name
-        if dest.exists():
-            continue  # should skip
-        shutil.copytree(skill_dir, dest)
+    _install_skills(skill_src, dest_root)
 
     # Original file must still be there; SKILL.md must NOT have been installed
     assert (existing / "ORIGINAL.md").exists()
@@ -73,18 +50,34 @@ def test_install_skills_cleans_up_tmp_on_error(tmp_path, skill_src):
     dest_root = tmp_path / "skills_dest"
     dest_root.mkdir()
 
-    skills_src_root = skill_src
-    for skill_dir in skills_src_root.iterdir():
-        if not skill_dir.is_dir():
-            continue
-        dest = dest_root / skill_dir.name
-        tmp_dest = dest.parent / (dest.name + "._installing")
-        try:
-            shutil.copytree(skill_dir, tmp_dest)
-            raise RuntimeError("simulated failure before rename")
-        except RuntimeError:
-            shutil.rmtree(tmp_dest, ignore_errors=True)
+    # Make copytree fail by making the tmp_dest unwritable after creation
+    original_copytree = shutil.copytree
+
+    def fail_copytree(src, dst, **kwargs):
+        original_copytree(src, dst, **kwargs)
+        raise OSError("simulated failure before rename")
+
+    with patch("plugins.omh.shutil.copytree", side_effect=fail_copytree):
+        _install_skills(skill_src, dest_root)
 
     # tmp dir must be cleaned up; dest must not have been created
     assert not (dest_root / "omh-test-skill._installing").exists()
     assert not (dest_root / "omh-test-skill").exists()
+
+
+def test_install_skills_creates_dest_root(tmp_path, skill_src):
+    dest_root = tmp_path / "nested" / "skills_dest"
+    # dest_root does not exist yet
+
+    _install_skills(skill_src, dest_root)
+
+    assert (dest_root / "omh-test-skill" / "SKILL.md").exists()
+
+
+def test_register_tools():
+    ctx = MagicMock()
+    with patch("plugins.omh._install_skills"):
+        from plugins.omh import register
+        register(ctx)
+    names = {c.args[0] for c in ctx.register_tool.call_args_list}
+    assert names == {"omh_state", "omh_gather_evidence"}


### PR DESCRIPTION
## Problem

Three issues with bundled omh skills:

1. **No category grouping** — skills were installed flat into `~/.hermes/skills/<skill-name>/` instead of `~/.hermes/skills/omh/<skill-name>/`, so they didn't appear under the `omh` category in `skills_list`.

2. **Wrong frontmatter schema** — `tags:` and `category:` were top-level fields; the schema requires them nested under `metadata.hermes:`.

3. **Descriptions truncated** — `extract_skill_description()` in `skill_utils.py` truncates at 60 chars (57 + `...`). All five descriptions were 248–347 chars, elided immediately after the opening words, hiding the trigger information the LLM needs to select the right skill.

## Changes

### Category grouping
- `_install_skills()` now targets `~/.hermes/skills/omh/<skill-name>/` so bundled skills appear under the `omh` category in `skills_list`
- Added optional `skills_src_root` / `skills_dest_root` args for testability without mocking
- Rewrote `test_init.py` to call `_install_skills()` directly (previous tests inlined the copy logic and never exercised the function)

### Frontmatter schema
- Moved `tags:` and `category:` from top-level into `metadata.hermes:` in all five SKILL.md files — original tag values preserved unchanged

### Description compression
Applied LLMLingua-2 compression principles (drop function words/articles/prepositions, keep nouns/verbs/domain terms, use symbols) to fit within the 60-char limit while maximising signal:

| Skill | Description |
|---|---|
| omh-autopilot | `pipeline: interview→plan→execute→QA→verify (idea→code)` |
| omh-deep-interview | `Socratic reqs interview; clarify vague/ambiguous goals` |
| omh-deep-research | `parallel web research; subagents→synthesis→cite-verify` |
| omh-ralph | `execute plan: 1 task/call, verify evidence, iron law` |
| omh-ralplan | `Planner+Architect+Critic→consensus impl plan (≤3 rounds)` |