### PR TITLE
omh-ralph-driving: dispatcher's playbook + reference templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Skills work standalone with zero dependencies.
 | **omh-ralplan-orchestration** | Dispatcher's playbook for driving an `omh-ralplan` run — context-package authoring (where quality is born), round dispatch, distillation, final review |
 | **omh-deep-interview** | Socratic requirements interview with coverage tracking |
 | **omh-ralph** | Verified execution: implement → verify → iterate until done |
+| **omh-ralph-driving** | Dispatcher's playbook for driving an `omh-ralph` run — plan-shape, parallel batching, evidence gathering, verifier discipline, strike categorization, Step-7 final architect review, commit hygiene |
 | **omh-autopilot** | Full pipeline composing all three skills end-to-end |
 
 Composition (recommended pipeline for unfamiliar domains):
@@ -31,7 +32,7 @@ domain is unfamiliar; otherwise start at the interview.)
 
 ```bash
 hermes skills tap add witt3rd/oh-my-hermes
-hermes skills install omh-deep-research omh-ralplan omh-ralplan-orchestration omh-deep-interview omh-ralph omh-autopilot
+hermes skills install omh-deep-research omh-ralplan omh-ralplan-orchestration omh-deep-interview omh-ralph omh-ralph-driving omh-autopilot
 ```
 
 Or copy `skills/<name>/` to `~/.hermes/skills/omh/` manually.
@@ -48,6 +49,7 @@ For local development (live edits via symlinks), see [CONTRIBUTING.md](CONTRIBUT
 - **Driving a ralplan run yourself?** → `omh-ralplan-orchestration` (load alongside `omh-ralplan`)
 - **Vague idea?** → `omh-deep-interview` then `omh-ralplan`
 - **Have a plan, need execution?** → `omh-ralph`
+- **Driving a ralph run yourself?** → `omh-ralph-driving` (load alongside `omh-ralph`)
 - **End-to-end?** → `omh-autopilot`
 
 OMH self-seeds a `.omh/` directory in the project on first use (with the

--- a/plugins/omh/skills/omh-ralph-driving/SKILL.md
+++ b/plugins/omh/skills/omh-ralph-driving/SKILL.md
@@ -1,0 +1,654 @@
+---
+name: omh-ralph-driving
+description: >
+  How to drive an omh-ralph run well as the dispatcher — plan-shape,
+  iteration cadence, parallel batching, evidence gathering, verifier
+  discipline, and commit hygiene across many iterations. The
+  iron-law of one-task-per-invocation is in omh-ralph itself; this
+  skill covers what the orchestrator does between invocations to
+  keep the loop moving cleanly: picking parallel-safe batches,
+  honoring "DO NOT modify <shared file>" discipline, distinguishing
+  executor strikes (test-infra vs spec-misread vs real bug),
+  Step-7 final architect review, and committing the loop to the
+  user's branch.
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [execution, ralph, orchestration, multi-agent, parallel, verification]
+    category: omh
+    requires_toolsets: [terminal, omh]
+---
+
+# OMH Ralph Driving — orchestrator's playbook for verified execution
+
+Load this skill alongside `omh-ralph` when you are the orchestrator
+dispatching the loop. `omh-ralph` is loaded by the role-tagged
+*workers* (executor / verifier / architect) — it covers the iron-law
+discipline inside each task's `delegate_task` call. This skill covers
+what *you* do as the dispatcher: plan-shape, iteration cadence,
+parallel batching, evidence gathering, verifier dispatch, strike
+handling, commit hygiene, and the final architect gate.
+
+The two skills have different readers and different jobs. Don't merge
+them — worker context is precious; the dispatcher's playbook should
+not ride into every subagent.
+
+This skill is the ralph-side counterpart to `omh-ralplan-orchestration`
+(which is the dispatcher playbook for ralplan, the design loop). The
+relationship is consistent: each method has a worker-side skill (used
+inside delegate_task) and a driver-side skill (used by the orchestrator
+between dispatches).
+
+## When to use ralph vs just write the code
+
+Use ralph when:
+
+- You have a plan with 5+ independently-acceptable tasks (from
+  `omh-ralplan` or hand-authored).
+- Quality-via-verification matters more than wall-clock — each task's
+  output must be evidence-graded before the next builds on it.
+- You want clean checkpoints across many work units (no context bloat).
+- Some tasks are independent and can run in parallel batches.
+
+Don't use ralph when:
+
+- The work is single-step or trivially obvious to write directly.
+- No plan exists yet — run `omh-ralplan` (or for an obvious goal,
+  `omh-deep-interview` first) before invoking ralph.
+- The user wants to skip verification (unusual; usually means the
+  work is small enough to do directly).
+
+## The arc of a ralph run
+
+```
+iter 1: pick eligible tasks → dispatch executors (parallel where safe)
+        → gather evidence → dispatch verifiers (parallel) → mark passes/fails
+        → update state → release lock → exit
+
+iter 2: re-invoke. Read state. Pick next batch. Same cycle.
+
+...
+
+iter N: all tasks pass → Step 7 final architect review → mark complete.
+```
+
+The orchestrator's job between iterations: pick the right batch, write
+the right context for each executor, gather the right evidence, parse
+the verifier verdicts, and decide whether to retry or move on.
+
+## The five-step playbook
+
+### 1. Read the plan; verify it is ralph-shaped
+
+A ralph plan is a list of numbered tasks, each with:
+
+- A clear title.
+- A description tight enough that an executor with no prior context
+  can implement it.
+- **Acceptance criteria that are testable.** Generic criteria like
+  "implementation is complete" are rejected by ralph's planning gate.
+- Dependencies (which other tasks must be done first).
+- Files-touched (for parallel-batch planning — see step 3).
+
+If the plan came from `omh-ralplan`, it is design-shaped, not ralph-shaped. The stance's "MV slice" section is your starting point; you may need to translate it to ralph's task format. Author `.omh/plans/ralph-plan.md` (or `.omh/plans/ralplan-<slug>.md` if it derives from a specific ralplan instance) with proper task structure.
+
+The plan does not need every task pre-authored to the same depth — it can grow. Ralph's planning gate parses what's there at first invocation; new tasks discovered during execution land via the `discovered: true` flag in state.
+
+### 2. Pick the right batch for each iteration
+
+Each ralph iteration does ONE unit of work. A "unit" can be:
+
+- One task (when the next eligible task is alone, or has shared file
+  footprint with other eligibles)
+- A batch of 2-4 tasks (when independents are eligible and have
+  disjoint touch sets)
+
+**Eligibility** = `passes: false` AND all dependencies met.
+
+**Disjoint touch sets** = the tasks do not modify the same files. Read
+the plan's "Files to modify/create" lists. If two eligible tasks both
+touch `bin/janus-new-being`, they are NOT parallel-safe — one owns
+the modification. If one touches `migrations/lib.py` and another
+touches `bin/_lineage.py`, they are parallel-safe.
+
+**Edge case — shared imports.** Even if files are disjoint, if Task A
+authors a helper that Task B imports, you may need Task A to land first.
+Surface this in dependency declarations during plan-authoring; if you
+miss it, the executor for B will surface the dependency mid-task.
+
+**Right batch size.** 2-4 tasks. Five+ in one batch overloads
+orchestrator parsing of executor reports + verifier dispatch in your
+own context window.
+
+### 3. Dispatch executors with rich context
+
+Each executor gets a fresh subagent. Subagents have NO memory of
+prior iterations, prior conversations, prior tasks. Encode everything
+they need in the dispatch context.
+
+The executor dispatch context must contain:
+
+- **Project root + branch.** Paths absolute, not relative.
+- **Prior state.** What tasks completed in earlier iterations, what
+  files now exist, what helpers/libraries are available to import.
+- **Learnings from prior tasks** that are relevant to this one. Pull
+  forward gotchas, naming conventions, architectural choices that
+  the executor needs to honor.
+- **The task itself.** Full title, description, acceptance criteria.
+- **Required reading.** Absolute paths to the canonical design,
+  prior tasks' outputs, similar siblings to pattern-match against.
+- **TDD instruction.** Failing test first, watch it fail, implement,
+  watch it pass, run full suite, commit. Make this explicit in
+  EVERY executor dispatch.
+- **Commit metadata.** Author identity, commit message shape, branch.
+- **DO NOT modify <list>.** Critically important under parallel
+  batches. See P3 below.
+
+Use the `[omh-role:executor]` marker in the goal — the OMH plugin
+auto-injects the executor role prompt via its `pre_llm_call` hook.
+Don't inline role text manually.
+
+A full template for the executor `goal` field — including TDD
+instructions, sibling-aware DO-NOT-modify discipline, commit metadata,
+and retry variations for each strike category — is at
+`references/executor-goal-template.md`. Adapt the variables; keep the
+structure.
+
+### 4. Gather evidence with `omh_gather_evidence` BEFORE dispatching verifiers
+
+After all executors complete, run the project's actual test/build/lint
+commands via `omh_gather_evidence`. This produces a structured
+`{results, all_pass, summary}` object the verifier can grade against.
+
+**Critical:** the verifier does NOT run evidence themselves. Gathering
+happens at the orchestrator level so you can verify executor claims
+match reality before the verifier reads them.
+
+**Allowlist gotcha.** `omh_gather_evidence` enforces a token-prefix
+allowlist (`~/.hermes/plugins/omh/config.yaml` →
+`evidence_tool.allowlist_prefixes`). Common project test commands like
+`uv run --with pytest --with pyyaml -m pytest` do NOT match
+`uv run pytest` because `--with` breaks the prefix. Either:
+
+- Use the matching prefix: `uv run pytest <args>` (preferred — keep
+  pytest as a project dev dep so `--with pytest` is unnecessary).
+- Add a custom prefix to the OMH config.
+- Wrap with a project-local script.
+
+If gather_evidence rejects your command, the symptom is `exit_code: -1,
+output: "Command not in allowlist"`. Re-form the command before
+dispatching the verifier.
+
+### 5. Dispatch verifiers in parallel (batched per task)
+
+For each completed task, dispatch a verifier subagent with:
+
+- `[omh-role:verifier]` marker (auto-injects the verifier role prompt).
+- The task's acceptance criteria (so they grade against the spec, not
+  the executor's interpretation of it).
+- The full evidence output (the verifier MUST see real test results,
+  not paraphrased success claims).
+- File paths to inspect.
+- Specific load-bearing checks that go beyond "tests pass" (e.g.,
+  "verify the mismatched-flag check happens BEFORE any filesystem
+  writes — if not, partial-flag invocations corrupt state").
+
+Verifiers run in parallel via batched `delegate_task(tasks=[...])` —
+same wall-clock savings as Round 2 ralplan reviewers.
+
+The verifier returns one of:
+
+- **APPROVE** / PASS — task's `passes` flag becomes `true`.
+- **REQUEST_CHANGES** / FAIL — record verdict, retry executor with the
+  feedback. Track strikes (see P5 below).
+
+A full template for the verifier `goal` field — including the
+acceptance-criteria-verbatim discipline, evidence-paste shape, sibling
+boundary checks, strike categorization, and worked verdict examples —
+is at `references/verifier-goal-template.md`.
+
+## Pitfalls (P1–P10)
+
+These are the failure modes that ralph dispatchers stumble into.
+Numbered for cross-reference; gaps reserved for future additions.
+
+### P1 — Plan must be ralph-shaped, not design-shaped
+
+`omh-ralplan` produces a `stance.md` — a design document. Ralph
+needs a task list with testable acceptance criteria.
+
+If you point ralph at a stance directly, the planning gate either
+parses it weakly (extracting whatever numbered sections look
+task-shaped) or refuses outright. Translate the stance's MV slice
+into a proper ralph plan first.
+
+The translation is mechanical:
+
+- Stance MV-slice items → ralph tasks (one item per task).
+- Stance test affordances → task acceptance criteria (verbatim where
+  the stance named them).
+- Stance "depends on" prose → task `dependencies:` field.
+- Stance file paths → task `files:` list (for parallel-batch
+  planning).
+
+Author the ralph plan as `.omh/plans/ralph-plan.md` or
+`.omh/plans/ralplan-<slug>.md`. Ralph's planning gate finds either.
+
+**Worked translation example (from the 2026-04-27 janus run).** The
+stance's "MV slice plan" section listed 13 work items spread across
+NOW (~3.5h, lineage capture before next provision) / NEXT (+72h, the
+update tool) / DEFERRED (later releases). The ralph plan landed each
+item as a task with this shape:
+
+```markdown
+### Task 4 — bin/janus-new-being: version stamp + seed-history snapshot
+
+**Files to modify:**
+- `bin/janus-new-being`
+
+**Files to create:**
+- `bin/tests/test_janus_new_being_lineage.py`
+
+**Description:**
+Patch `bin/janus-new-being` provisioning logic to write lineage data
+per the stance's NOW slice item 2. After successful provisioning,
+write `<profile>/.janus/version`, snapshot rendered template + plugin
+tree to `<profile>/.janus/seed-history/v1/` via post-write disk-read,
+compute MANIFEST with content hashes per file...
+
+**Acceptance criteria (verbatim from stance test affordance):**
+
+    def test_provision_writes_v1_lineage(tmp_path):
+        profile = tmp_path / "alice-janus"
+        # ... provision invocation ...
+        assert (profile / ".janus" / "version").read_text().strip() == "v1"
+        seed = profile / ".janus" / "seed-history" / "v1"
+        assert (seed / "SOUL.md").exists()
+        ...
+
+**Dependencies:** none (Task 5 extends, but doesn't conflict)
+```
+
+The translation discipline that made this work:
+
+1. **Verbatim acceptance criteria from the stance.** Where the stance
+   said `test_provision_writes_v1_lineage_and_gh_config` passes, the
+   ralph plan used that exact test name. This makes the executor
+   write the test the stance specified, and the verifier grade
+   against the stance's own contract — no drift through paraphrase.
+
+2. **Files-touched are explicit.** Each task's `files:` lists exactly
+   what gets created and modified. This is what enables parallel-
+   batch planning later (P2): the orchestrator can read the lists
+   and check disjoint touch sets without re-deriving them from the
+   description prose.
+
+3. **Dependencies are inferred from shared concrete artifacts, not
+   just prose.** The stance said the MANIFEST shape was authored in
+   Task 4; Task 8 (lib.py with `hash_equals_ancestor`) needs to read
+   that format. So Task 8's `dependencies: [task-4]` was inferred from
+   the shared file format, not from a "Task 8 must come after Task 4"
+   sentence.
+
+4. **NOW/NEXT/DEFERRED gets folded into priority ordering.** All
+   NOW-slice tasks get `priority: 1` or `priority: 2` (with
+   priority-2 reserved for ones that gate later parallel batches).
+   NEXT gets 3-5. DEFERRED items don't appear as ralph tasks at all
+   — they're not part of this run's work envelope.
+
+5. **Test affordance section per task gets expanded to full pytest
+   function signatures.** The stance often listed test names with
+   brief shape; the ralph task gives the executor the exact function
+   names + behavior so they don't have to re-derive them.
+
+**The translation is its own load-bearing step.** Doing it sloppy
+produces a sloppy run no matter how disciplined the orchestration is
+afterward. The ralph plan IS the contract executors implement and
+verifiers grade against; if it's vague, the loop produces vague work.
+
+Budget 30-60 minutes for the translation on a 10+ task plan. The
+output is the file ralph's planning gate parses; you'll never look at
+the stance directly again during the run.
+
+### P2 — Identify parallel-safe batches before dispatching, not during
+
+Walk all eligible tasks (`passes: false` + deps met) at the start of
+each iteration. For each pair, check disjoint-touch-set. Mark the
+parallel-safe set; dispatch them in one batched `delegate_task`.
+
+If you wait until after dispatching one task to consider whether
+others could have run in parallel, you've forfeited the wall-clock
+savings for that iteration. The right-time-to-decide is at the start
+of the iteration, when you're already reading state.
+
+Right batch size is 2-4. Two if dependencies are tight; four if
+multiple independents stack. Five-plus overloads the orchestrator's
+own context with executor reports + parallel verifier dispatches.
+
+### P3 — "DO NOT modify <shared file>" must be explicit in parallel dispatch contexts
+
+When dispatching parallel executors, only ONE task owns each shared
+file. The other executors must import (read-only) but not modify it.
+
+Encode this explicitly in each executor's dispatch context:
+
+> DO NOT modify migrations/lib.py during this task — Task X owns that
+> change. Import what you need; if a function isn't there yet, fall
+> back to inline implementation that matches Task X's expected
+> signature so they converge cleanly when both commits land.
+
+Without this instruction, parallel executors race on the shared file
+and produce conflicting commits. With it, they respect the boundary
+and commit only their own work.
+
+The instruction should also tell each executor to **unstage sibling
+tasks' files before commit**. Otherwise `git add -A` sweeps in
+neighbors' uncommitted work — see P9.
+
+### P4 — Encode forward-learnings in each executor dispatch
+
+Each iteration produces learnings (gotchas, naming conventions,
+patterns that worked, patterns that failed). The next iteration's
+executors do NOT see these unless you encode them.
+
+Maintain a per-iteration learnings list in the ralph state's
+`completed_task_learnings` field, and include the relevant subset in
+each subsequent executor's dispatch context.
+
+Examples worth encoding forward:
+
+- "TEST-INFRA: never use `hash(content) & 0xffff` for tmpdir naming
+  — randomized + small modulus = collision risk."
+- "Use `git rm -r` (not `rm -rf`) to preserve git history when
+  removing tracked files."
+- "bin/janus-new-being uses uv shebang, no .py suffix; new bin/*
+  scripts should follow the same pattern."
+- "The classify() function in bin/_lineage.py ships the criterion
+  (path-prefix patterns + Class-B exact set), not enumeration. Reuse
+  it; don't duplicate the taxonomy."
+
+These compress and ride forward via the dispatch context. The
+omh-ralph state's `completed_task_learnings` is the canonical store.
+
+### P5 — Distinguish executor strikes by category
+
+When the verifier returns REQUEST_CHANGES, the cause is one of:
+
+1. **Test-infra** — the test itself is buggy (e.g., a `hash() & 0xffff`
+   path collision, a fixture race, a test runner config issue). The
+   implementation may be correct; only the test needs fixing.
+
+2. **Spec-misread** — the executor implemented something different
+   from what the acceptance criteria asked for. Implementation needs
+   correction.
+
+3. **Implementation bug** — the executor implemented the right thing
+   but it has a real defect (logic error, edge case missed, security
+   issue).
+
+These three categories take different fixes. Test-infra retries
+should touch only the test file. Spec-misread retries need fresh
+context emphasizing what the spec actually requires. Implementation-
+bug retries need the failing case named explicitly.
+
+Tag the strike category in the error fingerprint when updating state:
+
+```python
+"error_fingerprints": [
+    {"category": "test-infra", "error_key": "hash-collision-in-tmpdir-naming", "round": 1},
+    ...
+]
+```
+
+The 3-strike circuit breaker (per `omh-ralph` Step 6) fires when the
+same `(category, error_key)` repeats three times. Tagging by category
+prevents test-infra strikes from masking real bugs (or vice versa).
+
+### P6 — Verifiers must read real evidence, not executor claims
+
+Always run `omh_gather_evidence` before dispatching verifiers.
+Include the evidence output in the verifier's dispatch context.
+
+If you skip evidence-gathering, the verifier reads only the executor's
+report ("Status: COMPLETE; 5 tests pass; commit X") and has no
+ground truth to grade against. Executor reports are sometimes wrong
+— either the executor genuinely missed something, or a test passed
+for the wrong reason (e.g., a path-collision crashing before the
+load-bearing assertion ran — see this skill's worked example).
+
+The orchestrator-runs-evidence pattern is what makes ralph
+verification trustworthy.
+
+### P7 — Final architect review (Step 7) is the merge gate
+
+When all tasks pass, ralph's Step 7 dispatches an architect to review
+the full implementation against the original plan/stance.
+
+The architect reviews HOLISTICALLY:
+
+- Architectural fidelity (did the implementation honor the design?)
+- Principle alignment (do load-bearing principles fire in mechanics,
+  not just appear in prose?)
+- MV slice readiness (can the user actually run this tonight?)
+- Architectural seams (anything rough vs explicitly deferred?)
+- Commit hygiene (is the git history clean enough to merge?)
+- Test affordance gaps
+
+This is the orchestrator's final gate before handing the user a
+PR-ready branch. The architect can return:
+
+- **APPROVE** — seal-of-merge.
+- **APPROVE_WITH_PROVISO** — small foldable additions before merge
+  (typically 1-3 named items).
+- **REQUEST_CHANGES** — something cannot ship; new tasks added with
+  `discovered: true`.
+
+Author the architect's review as `<orchestrator>-architect-review.md`
+in the design directory (the orchestrator's own iteration-level review
+is `<orchestrator>-review.md`; the architect-review is a separate
+artifact).
+
+A full template for the architect-final-review `goal` field — including
+the diff-range walk, end-to-end MV-slice trace, principle-firing audit,
+commit-hygiene check, verdict calibration guidance, and worked review
+examples (APPROVE_WITH_PROVISO and REQUEST_CHANGES) — is at
+`references/architect-final-review-template.md`.
+
+### P8 — Update state at every action; release lock at every exit
+
+Per `omh-ralph` Step 0/Step 8: state files at
+`.omh/state/ralph--<instance_id>.json` and
+`.omh/state/ralph-tasks--<instance_id>.json` track the run. Lock at
+`.omh/state/ralph--<instance_id>.lock` prevents concurrent sessions
+racing on the same plan.
+
+Discipline:
+
+- Acquire the lock at iteration start (Step 0).
+- Update state after every executor completion, every verifier
+  verdict, every task transition.
+- Release the lock at every exit point — success, blocked, cancel,
+  max-iterations, exception. Wrap the iteration body so unlock fires
+  even on error.
+
+Do NOT leave stale locks. If a lock is held by a dead process, the
+next ralph invocation will surface it via `held_by` — offer to cancel
++ retry, don't silently steal.
+
+### P9 — Commit hygiene under parallel writes
+
+Three executors writing to the same branch in one orchestrator turn
+will see *partial* state from each other (whatever has been committed)
+but NOT each other's uncommitted work. If one executor uses
+`git add -A` to stage their commit, they may sweep in sibling
+executors' files that are still in-flight.
+
+Discipline for parallel-executor dispatch:
+
+1. **Tell each executor to `git add` their specific files explicitly**,
+   not `git add -A`. Names match the task's `files:` field.
+
+2. **Tell each executor to check `git status` before commit**: if
+   sibling tasks' files are present and unstaged, do NOT include them.
+   Common sibling files: untracked __init__.py stubs, untracked test
+   files, RELEASES.yaml mid-edit.
+
+3. **Accept that absorption sometimes happens anyway.** When it does,
+   the failure is recoverable: an interactive rebase squashes the
+   over-broad commit with the missing one, OR a follow-up history-note
+   commit explains the boundary.
+
+4. **Surface the absorption in iteration logs.** If you notice an
+   executor reported "swept in pre-existing untracked files," flag it
+   for the architect's commit-hygiene check at Step 7.
+
+This pattern was learned the hard way: in one run, task-11's commit
+absorbed ~60% of task-12's intended-commit content via `git add -A`.
+Tests stayed green; deliverables were correct; commit boundaries were
+fuzzy. Architect flagged it as a foldable proviso.
+
+### P10 — Resume vs restart matters for plugin/tool changes
+
+If the user makes plugin or toolset changes between iterations
+(adding a tool, enabling a plugin, modifying config.yaml), tools do
+NOT register live in the current session. They register at agent
+**boot**.
+
+If the user says "I changed the config, can you use the new tool now?":
+
+- The session needs a full restart, not just a Resume button click
+  (some chat UIs reuse the same agent process across "Resume").
+- Verify by checking your function schema — if the new tool isn't
+  there, the boot didn't happen.
+- The fastest way to know is `omh_state(action="check", ...)` if
+  it's an OMH-related plugin — if the tool errors with
+  "function not found," the plugin isn't loaded.
+
+See sibling skill `enabling-hermes-plugin-in-profile` for the full
+plugin-install diagnostic ladder if tools genuinely don't surface
+after restart.
+
+## State management cheat sheet
+
+```python
+# Step 0: check + lock
+omh_state(action="cancel_check", mode="ralph", instance_id=instance_id)
+lock = omh_state(action="lock", mode="ralph", lock_key=instance_id,
+                  session_id=session_id, holder_note="...")
+
+# Step 1: read state (or trigger planning gate)
+state = omh_state(action="read", mode="ralph", instance_id=instance_id)
+tasks = omh_state(action="read", mode="ralph-tasks", instance_id=instance_id)
+
+# Step 2: planning gate (only on first invocation)
+omh_state(action="write", mode="ralph-tasks", instance_id=instance_id, data={
+    "tasks": [{"id": "task-1", "title": "...", "description": "...",
+               "acceptance_criteria": "...", "priority": 1,
+               "dependencies": [], "passes": False, "files": [...]}, ...]
+})
+
+# Step 3-5: per-iteration execution
+# (delegate_task for executors, omh_gather_evidence, delegate_task for verifiers)
+
+# Step 8: update state, exit
+omh_state(action="write", mode="ralph", instance_id=instance_id, data={
+    "active": True, "phase": "execute", "iteration": N, ...,
+    "completed_task_learnings": [...]
+})
+omh_state(action="unlock", mode="ralph", lock_key=instance_id, session_id=session_id)
+```
+
+## What "done" looks like for the orchestrator
+
+- All tasks have `passes: true` in ralph-tasks state.
+- Step 7 final architect review: APPROVE or APPROVE_WITH_PROVISO with
+  provisos folded.
+- `<orchestrator>-architect-review.md` written.
+- `.omh/logs/ralph-progress.md` (or domain-equivalent) names the
+  iteration arc, strikes encountered, and key learnings.
+- State marked `phase: complete`, `active: false`.
+- Lock released.
+- The user can open a PR from the branch.
+
+## Worked example (2026-04-27, janus migration)
+
+13-task plan, 5 iterations, 1 strike total, final APPROVE_WITH_PROVISO.
+
+- **iter 1**: 3 independents (RELEASES.yaml, AGENT.md patch, retire
+  janus-migration skill) in parallel. All APPROVE.
+- **iter 2**: task-4 solo (lineage capture, gates 5/6/8). Strike 1
+  was test-infra hash collision. APPROVE on retry.
+- **iter 3**: 3 parallel (gh-config, backfill-lineage, lib.py). Each
+  task's dispatch said "DO NOT modify bin/_lineage.py — Task X owns
+  it." Strike-zero round.
+- **iter 4**: 3 parallel (janus-migrate skill, janus-update CLI,
+  pytest harness). Strike-zero.
+- **iter 5**: 3 parallel (boot-context surface, janus-contribute stub,
+  v2 migrations). Strike-zero. **One commit-hygiene issue:** task-11
+  absorbed task-12 files via `git add -A`. Tests green; flagged for
+  architect review.
+- **Step 7**: architect APPROVE_WITH_PROVISO, two foldable items
+  (commit-hygiene rebase + missing migrations/README.md).
+
+Total: 0 → 132 tests across 14 implementation commits. The discipline
+that made this strike-zero across 4/5 parallel iterations was P3
+("DO NOT modify <shared file>") + P4 (forward-learnings encoding) +
+P6 (orchestrator-runs-evidence). The one strike was P5 test-infra,
+recovered cleanly.
+
+## Maintaining your own run log
+
+Each ralph run that produces new pitfalls or surprising patterns is
+worth logging. Keep a short table:
+
+| Date | Domain | Iters | Strikes | Surprises | Patches to this skill |
+|------|--------|-------|---------|-----------|------------------------|
+
+Don't let this skill turn into a session log. Log somewhere else
+(your substrate, project notes, a wiki). Patch this skill only when
+a pitfall is general enough to teach a future orchestrator.
+
+## Related skills
+
+- `omh-ralph` — the worker-side discipline, loaded inside each
+  delegate_task. Required reading for the orchestrator (one-off, to
+  understand what the workers are doing) but not loaded into worker
+  context (they auto-inject role prompts via the plugin).
+- `omh-ralplan-orchestration` — the dispatcher playbook for the
+  design loop. Use BEFORE ralph if no plan exists yet. Same shape
+  (driver-side skill) for a different method (consensus design vs
+  verified execution).
+- `omh-ralplan` — the worker-side design discipline. Use only inside
+  delegate_task with `[omh-role:planner|architect|critic]` markers.
+- `enabling-hermes-plugin-in-profile` — sibling skill for the
+  plugin-install diagnostic ladder. Cite if a ralph run is blocked
+  because OMH tools aren't in the function schema.
+- `subagent-driven-development` — the simpler shape for plans without
+  the OMH plugin available. Same architectural pattern but without
+  state machinery, role injection, or evidence tooling.
+
+## Do-not-lose content
+
+The single most load-bearing insight: **the orchestrator runs evidence,
+not the verifier.** Always `omh_gather_evidence` BEFORE dispatching
+the verifier. Include real test output in the verifier's context.
+This is what makes ralph's verdicts trustworthy; without it, you have
+two layers of executor-self-reporting.
+
+Second: **"DO NOT modify <shared file>" is the discipline that makes
+parallel batches of 3 work.** Every parallel-executor dispatch must
+name what files belong to siblings. Without this, parallel batches
+race on shared files and one task's commit absorbs another's work.
+
+Third: **strikes have categories.** Test-infra ≠ spec-misread ≠
+implementation-bug. Tag the category; the 3-strike circuit breaker
+should fire on the *same* category, not just the same task. Mixing
+categories produces false-positive halts (or worse, false-negatives
+where a real bug masquerades as test-infra).
+
+Fourth: **the orchestrator's altitude is "between iterations,"**
+not inside any one task. The iron-law of one-task-per-invocation
+exists so you can stay at altitude — picking batches, encoding
+learnings forward, gathering evidence, dispatching verifiers,
+deciding retry vs advance. Drop into the work and you become an
+executor; the loop's whole value collapses.

--- a/plugins/omh/skills/omh-ralph-driving/references/architect-final-review-template.md
+++ b/plugins/omh/skills/omh-ralph-driving/references/architect-final-review-template.md
@@ -1,0 +1,248 @@
+# Architect final review template
+
+Used as the `goal` field in `delegate_task` for the Step 7 final
+architect review — the merge gate at the end of a ralph run, after
+all tasks have `passes: true`. This is the orchestrator's last gate
+before handing the user a PR-ready branch.
+
+This is NOT the per-iteration verifier (that's `verifier-goal-template.md`).
+The architect reviews the full implementation HOLISTICALLY — across
+all tasks, against the original plan/stance, with attention to seams
+the per-task verifiers couldn't see.
+
+```
+[omh-role:architect] Final review of <domain> ralph run for merge readiness.
+
+## Project root + branch
+
+- Repo: <absolute path>
+- Branch: <branch name>
+- Tasks completed: <N> (all `passes: true` in ralph-tasks state)
+- Iterations: <M>
+- Strikes encountered: <K> (categorized: <X test-infra, Y spec-misread,
+  Z impl-bug>)
+
+## Required reading
+
+The original design (read first):
+- <absolute path to stance.md or design doc>
+- <absolute path to PRINCIPLES.md or directives>
+
+The plan that was executed:
+- <absolute path to .omh/plans/ralph-plan.md or ralplan-<slug>.md>
+
+The implementation (the full diff range):
+- `git log --oneline <base>..<head>` — N implementation commits
+- For each commit, `git show <sha>` (the architect should walk the
+  diff range, not just check tip-of-tree)
+
+The orchestrator's iteration log (if present):
+- <absolute path to .omh/logs/ralph-progress.md or domain equivalent>
+
+Per-task state:
+- `.omh/state/ralph-tasks--<instance_id>.json` for verifier verdicts +
+  forward-encoded learnings.
+
+## Your job
+
+Review the FULL implementation against the original plan/stance. Per-
+task verifiers already graded each task in isolation — your job is
+the cross-task / cross-iteration view they could not have. Specifically:
+
+1. **Architectural fidelity.** Did the implementation honor the design
+   stance? Are load-bearing positions visible in the code, or only in
+   prose? Cite stance sections.
+
+2. **Principle alignment.** Do the principles fire in the mechanics,
+   or only in comments? A principle that's documented but not
+   enforced by code is a principle-derivation without teeth.
+
+3. **MV slice readiness.** Can the user actually run this tonight?
+   Walk the user-facing entry points; trace one realistic invocation
+   end-to-end. Anything missing?
+
+4. **Architectural seams.** Anything rough that wasn't explicitly
+   deferred in the stance? Is the rough edge documented (RELEASES.yaml,
+   issue tracker, or stance "Open questions" section)?
+
+5. **Commit hygiene.** Walk `git log --oneline <range>`. Each commit
+   should map to one task; commit messages should cite plan task IDs.
+   If P9 commit-absorption happened (sibling files swept via
+   `git add -A`), flag it as foldable.
+
+6. **Test affordance gaps.** Per-task verifiers checked the per-task
+   tests. Are there integration / cross-task tests the plan named
+   that didn't get implemented? Are there integration cases that
+   should exist but weren't named?
+
+7. **Discovered tasks.** If any tasks landed mid-run with
+   `discovered: true`, were they completed? Are there unsurfaced
+   discoveries (gaps the architect sees that the per-task verifiers
+   missed)?
+
+8. **Documentation surface.** Did user-facing docs (README, AGENT.md,
+   CONTRIBUTING.md, etc.) get updated to reflect the new mechanism?
+   A merged feature with stale README is a half-merge.
+
+## Specific things to verify (orchestrator-named)
+
+- <Stance-flagged "must verify at end" items the orchestrator wants
+  the architect to confirm>
+- <Specific principle-firing checks the orchestrator suspects might
+  be prose-only>
+- <Cross-task invariants only visible at the end>
+
+## Output expected
+
+Produce a ~1500-3000 word architect review at:
+`<absolute path to <orchestrator>-architect-review.md>`
+
+This is a separate artifact from the orchestrator's own iteration
+review (`<orchestrator>-review.md`). Both ride; they have different
+authors and different jobs.
+
+Structure:
+
+- **Verdict:** APPROVE / APPROVE_WITH_PROVISO / REQUEST_CHANGES
+- **One-paragraph summary:** what the run produced + whether it ships.
+- **Architectural fidelity:** does code match stance? cite.
+- **Principle alignment:** which principles fire in mechanics; which
+  are prose-only.
+- **MV slice readiness:** end-to-end trace of one realistic invocation;
+  what's missing or rough.
+- **Architectural seams:** rough edges; for each, foldable / deferred-
+  with-issue / blocking.
+- **Commit hygiene:** clean / fuzzy with names / blocked.
+- **Test affordance gaps:** named gaps + recommended adds.
+- **Provisos (if APPROVE_WITH_PROVISO):** numbered list, each with:
+  what / why fold-not-block / where to add it.
+- **Discovered tasks (if REQUEST_CHANGES):** new tasks the architect
+  surfaces, in `discovered: true` shape, ready for the orchestrator to
+  add to ralph-tasks state.
+- **What this run proved about the plan:** any plan-shape feedback
+  worth folding into future ralplan/ralph runs.
+```
+
+## The three verdicts
+
+### APPROVE
+
+Seal-of-merge. The branch is ready for PR. No follow-ups required
+before merge. The architect-review still ships as a record of the
+review, but the PR can land.
+
+When to issue: stance honored, principles fire in mechanics, MV slice
+walks cleanly end-to-end, commit hygiene clean, no architectural seams
+left rough without explicit deferral.
+
+### APPROVE_WITH_PROVISO
+
+Small foldable items must land before merge — typically 1-3 of:
+- A missed README/CONTRIBUTING/AGENT.md update.
+- A commit-history rebase to fix P9 absorption.
+- A missing test affordance the plan named but didn't enforce.
+- A small edge-case fix the verifier missed in isolation.
+
+Each proviso is named explicitly with what / where / why. The
+orchestrator folds them as a follow-up commit (or an interactive
+rebase for history fixes), then merges.
+
+When NOT to issue: if the proviso would require >1 hour of work or
+re-opens a load-bearing decision, that's REQUEST_CHANGES, not a
+proviso. Provisos are foldable; if it's not foldable, don't fold it.
+
+### REQUEST_CHANGES
+
+Something cannot ship as-is. The architect surfaces:
+
+- New tasks (in `discovered: true` shape) the orchestrator adds to
+  ralph-tasks state.
+- A specific failing case that the test suite missed.
+- An architectural drift between stance and implementation that
+  must be reconciled before merge.
+
+The ralph loop resumes with these tasks; the architect re-reviews on
+the next Step 7 cycle.
+
+## Key things to include EVERY time
+
+- **The diff range** — `<base>..<head>` walked commit-by-commit, not
+  just tip-of-tree inspection. Cross-task seams are only visible
+  across commits.
+- **End-to-end MV-slice trace** — pick one realistic user invocation,
+  walk it through the code, name what's missing. Per-task verifiers
+  can't catch end-to-end gaps.
+- **Principle-firing audit** — for each load-bearing principle from
+  the stance, is it enforced by code or only documented in prose?
+- **Commit hygiene check** — walk `git log --oneline <range>`; flag
+  P9 absorptions for foldable rebase.
+- **Documentation surface check** — README / AGENT.md / etc. updated
+  to match the merged feature. Stale docs = half-merge.
+
+## On verdict calibration
+
+A perfect APPROVE on a multi-task run is rare. APPROVE_WITH_PROVISO
+is the common outcome — small things slip past per-task verifiers
+that the architect catches at altitude. Don't avoid APPROVE_WITH_PROVISO
+to seem decisive; the proviso is what makes the architect's seat
+worth occupying.
+
+REQUEST_CHANGES at Step 7 is uncommon but real. If the run drifted
+architecturally and per-task verifiers didn't catch it (because each
+task in isolation looked fine), this is the gate that catches it.
+Don't soften REQUEST_CHANGES into APPROVE_WITH_PROVISO when the
+problem is structural — provisos are foldable; structural drift is
+not.
+
+## Worked review examples
+
+### APPROVE_WITH_PROVISO (typical)
+
+> Verdict: APPROVE_WITH_PROVISO
+>
+> The 13-task janus-migration ralph run honored the stance: lineage
+> capture lands at `bin/janus-new-being`, `classify()` ships taxonomy-
+> as-criterion (P-reuse), the v1→v2 migrations machinery exists at
+> `migrations/lib.py:hash_equals_ancestor`. MV slice walks cleanly:
+> a fresh `janus-new-being --with-gh` provision writes
+> `.janus/version` + `seed-history/v1/MANIFEST` with content hashes,
+> verified by `test_provision_writes_v1_lineage_and_gh_config`.
+>
+> Two foldable provisos:
+>
+> 1. **Commit-hygiene rebase.** task-11's commit absorbed ~60% of
+>    task-12's intended-commit content via `git add -A` (executor
+>    swept untracked __init__.py + RELEASES.yaml mid-edit). Tests are
+>    green; deliverables correct. Interactive rebase splits the two
+>    commits along their `files:` field boundaries before PR.
+> 2. **migrations/README.md missing.** The plan named the v2-
+>    migrations directory but no README.md was added describing the
+>    on-disk layout. Add a 30-line README before merge.
+
+### REQUEST_CHANGES (uncommon, structural)
+
+> Verdict: REQUEST_CHANGES
+>
+> Per-task verifiers each APPROVE-d their tasks. The cross-task seam
+> they couldn't see: task-4 writes the MANIFEST in `<profile>/.janus/
+> seed-history/v1/MANIFEST` but task-8's `hash_equals_ancestor()`
+> reads from `<profile>/.janus/MANIFEST` (no seed-history/v1/ prefix).
+> Both tests pass in isolation (task-4 reads its own write; task-8 has
+> a fixture that writes to its own location). Realistic invocation
+> fails: `janus-update` provisioned via task-4 cannot be diffed by the
+> task-8 helper because the paths don't match.
+>
+> Discovered task:
+>
+> ```
+> task-14 (discovered: true):
+>   title: Reconcile MANIFEST path between janus-new-being and
+>          migrations/lib.py:hash_equals_ancestor
+>   files: bin/janus-new-being, migrations/lib.py, integration test
+>   acceptance: test_provision_then_compare_manifest_e2e passes
+>          (provisions a profile, then calls hash_equals_ancestor
+>          on the same path; both must agree)
+>   priority: 1
+> ```
+>
+> Resume the loop with task-14; re-review at next Step 7.

--- a/plugins/omh/skills/omh-ralph-driving/references/executor-goal-template.md
+++ b/plugins/omh/skills/omh-ralph-driving/references/executor-goal-template.md
@@ -1,0 +1,216 @@
+# Executor goal template
+
+Used as the `goal` field in `delegate_task` for an executor subagent
+implementing one task in a ralph iteration. Adapt the variables. Keep
+the structure — every section earns its place because the subagent has
+NO memory of prior iterations, prior tasks, prior conversations.
+
+```
+[omh-role:executor] Task <N> — <one-line task title from the plan>
+
+## Project root + branch
+
+- Repo: <absolute path>
+- Branch: <branch name>
+- Commit author: <Name <email>>
+
+All paths below are absolute. Subagents do not have `cd`-awareness.
+
+## The task
+
+<Full title + description from the ralph plan, verbatim. Do not
+paraphrase — the verifier will grade against the plan, and any drift
+between this dispatch and the plan becomes a strike.>
+
+## Acceptance criteria
+
+<Verbatim from the ralph plan. If the plan named a specific test
+function (e.g. `test_provision_writes_v1_lineage`), the executor MUST
+implement THAT test, not a paraphrase. Drift here = spec-misread
+strike (P5).>
+
+## Files this task owns
+
+Modify:
+- <absolute path>
+- <absolute path>
+
+Create:
+- <absolute path>
+
+## DO NOT modify (sibling tasks own these)
+
+- <absolute path> — owned by Task <M> (running in parallel this iteration)
+- <absolute path> — owned by Task <K> (running in parallel this iteration)
+
+If you need a function from a sibling-owned file that does not yet
+exist, fall back to inline implementation that matches the sibling's
+expected signature (named in `## Required reading` below). The two
+commits will converge cleanly when both land.
+
+## Prior state (what exists going into this iteration)
+
+Iterations completed: <N-1>
+
+Tasks completed and what they produced:
+- Task <M>: <one-line outcome + key files created/modified>
+- Task <K>: <...>
+
+Helpers / libraries now available to import:
+- `<module path>` exposes `<function/class>(<signature>)` — <one-line use>
+- ...
+
+## Forward-encoded learnings (P4 — relevant to THIS task)
+
+From prior iterations:
+- <gotcha or convention the executor must honor; cite the iteration
+  it was learned in if useful>
+- ...
+
+Example shapes (drop the ones that don't apply):
+- TEST-INFRA: <pattern that bit a previous executor; e.g. "never use
+  `hash(content) & 0xffff` for tmpdir naming — randomized + small
+  modulus = collision risk">
+- NAMING: <project convention; e.g. "bin/* scripts use uv shebang and
+  no .py suffix">
+- REUSE: <existing helper; e.g. "classify() in bin/_lineage.py ships
+  the criterion — reuse it; don't duplicate the taxonomy">
+- HISTORY: <git discipline; e.g. "use `git rm -r` not `rm -rf` to
+  preserve history when removing tracked files">
+
+## Required reading (open these files; do not work from summaries)
+
+Canonical design:
+- <absolute path to stance.md or design doc> — read first
+- <absolute path to PRINCIPLES.md or directives>
+
+Adjacent siblings to pattern-match against:
+- <absolute path to similar in-tree file the new code should resemble>
+
+Prior tasks' outputs you will build on or import from:
+- <absolute path>
+
+## TDD instruction (every executor dispatch, every time)
+
+1. Author the failing test FIRST. Run it. Watch it fail with the
+   expected error (not an import error or syntax error — a real
+   assertion failure that names what's missing).
+2. Implement the production code.
+3. Run the test. Watch it pass.
+4. Run the full project suite (the orchestrator will run evidence-
+   gathering separately, but you should run it locally too). Confirm
+   no regressions.
+5. Commit (see `## Commit metadata` below).
+
+Do NOT skip step 1. A passing test that was authored after the
+implementation is not a TDD-grade test; the verifier may catch this
+as test-after coding and request changes.
+
+## Commit metadata
+
+- Stage explicitly: `git add <each file from "Files this task owns">`.
+  Do NOT `git add -A`. Sibling tasks may have uncommitted files in
+  the working tree (see P9 in `omh-ralph-driving` SKILL.md).
+- Run `git status` before commit. If sibling task files are present
+  and unstaged, do NOT include them. If they're staged from a prior
+  step in your own work, that's fine.
+- Commit message shape:
+  ```
+  <task-id>: <one-line summary>
+
+  <Optional 2-4 line body explaining what changed and why, citing
+  acceptance criteria or test names where useful.>
+
+  Refs: <plan path or task ID>
+  ```
+- Branch: stay on `<branch name>` from the project root + branch
+  section. Do not create a new branch.
+- Author identity: <commit author from above>.
+
+## What "done" looks like for this task
+
+1. Failing test authored and committed (or in same commit as impl —
+   project's choice; default = same commit).
+2. Implementation passes the test.
+3. Full project suite passes (no regressions).
+4. Commit lands on <branch name> with the message shape above.
+5. The files listed under `## Files this task owns` are the only
+   files touched. Sibling-owned files are unchanged.
+
+## Output expected back to the orchestrator
+
+A report with:
+- **Status:** COMPLETE / BLOCKED / PARTIAL
+- **Commit:** <sha>
+- **Files touched:** <list>
+- **Tests added/passing:** <list>
+- **Anything you swept up by accident:** <files that ended up in your
+  commit that weren't in the "Files this task owns" list — be honest;
+  the architect's Step 7 commit-hygiene check needs this signal>
+- **Learnings worth forwarding:** <gotchas or conventions worth
+  encoding into future executors' P4 sections>
+- **Open questions:** <if any — surface, don't paper over>
+```
+
+## Key things to include EVERY time
+
+- **Absolute paths.** Subagents have no `cd`-awareness.
+- **The task description verbatim from the plan.** Paraphrase = drift
+  = spec-misread strike.
+- **Acceptance criteria verbatim from the plan,** especially exact
+  test function names where the plan named them.
+- **DO NOT modify <list>.** Critical under parallel batches. Without
+  it, parallel executors race on shared files (P3).
+- **Forward-encoded learnings (P4).** Each iteration produces gotchas;
+  the next iteration's executors do NOT see them unless you encode.
+- **Explicit `git add` (not `-A`).** P9 commit-hygiene discipline.
+- **TDD instruction.** Make it explicit every time, even if the
+  executor "should know."
+
+## Variations
+
+- **Retry after REQUEST_CHANGES (test-infra strike):** add at top:
+  ```
+  ## Prior strike: TEST-INFRA
+
+  Prior verifier feedback: <verbatim>. The test itself was buggy
+  (e.g., `<specific issue>`). Fix the test; the implementation may
+  already be correct. Re-run; if impl + new test still fail,
+  diagnose impl.
+  ```
+- **Retry after REQUEST_CHANGES (spec-misread strike):** emphasize the
+  acceptance-criteria section with what was misread:
+  ```
+  ## Prior strike: SPEC-MISREAD
+
+  Prior verifier feedback: <verbatim>. The implementation diverged
+  from the acceptance criteria as follows: <named drift>. Re-read
+  the criteria; implement what they specify, not what feels natural.
+  ```
+- **Retry after REQUEST_CHANGES (implementation-bug strike):** name the
+  failing case explicitly:
+  ```
+  ## Prior strike: IMPLEMENTATION-BUG
+
+  Prior verifier feedback: <verbatim>. Failing case: <specific
+  input/scenario>. Add a test that reproduces this case, then fix.
+  ```
+- **First-of-batch (no prior state):** drop the "Prior state" section
+  or use it for the project's pre-ralph baseline (e.g., "fresh branch
+  from main; no ralph tasks completed yet").
+- **Solo task (no parallel siblings):** drop "DO NOT modify" — but
+  KEEP the explicit `git add` discipline. P9 still applies if the
+  working tree has untracked files from earlier orchestrator work.
+
+## On strike categories (P5 cross-reference)
+
+Verifier returns one of three REQUEST_CHANGES shapes:
+
+1. **TEST-INFRA** — test buggy, impl may be fine. Fix the test.
+2. **SPEC-MISREAD** — impl diverged from criteria. Re-read, redo.
+3. **IMPLEMENTATION-BUG** — impl has a real defect. Reproduce + fix.
+
+Tag the retry dispatch with the category (see Variations above) so
+the executor knows where to focus. The 3-strike circuit breaker fires
+on the same `(category, error_key)` repeating — mixing categories
+masks real bugs (or vice versa).

--- a/plugins/omh/skills/omh-ralph-driving/references/verifier-goal-template.md
+++ b/plugins/omh/skills/omh-ralph-driving/references/verifier-goal-template.md
@@ -1,0 +1,209 @@
+# Verifier goal template
+
+Used as the `goal` field in `delegate_task` for a verifier subagent
+grading one completed task. Verifiers run in parallel — batch them via
+`delegate_task(tasks=[...])` after `omh_gather_evidence` produces real
+test output.
+
+The verifier MUST grade against the plan's acceptance criteria, not
+the executor's interpretation of them. The orchestrator runs evidence
+(P6); the verifier reads it. Without this, you have two layers of
+executor self-reporting.
+
+```
+[omh-role:verifier] Verify Task <N> — <one-line task title>
+
+## Project root + branch
+
+- Repo: <absolute path>
+- Branch: <branch name>
+- Commit under review: <sha from executor's report>
+
+## The task as specified
+
+<Full task title + description from the ralph plan, verbatim. Same
+text the executor saw. If the executor saw a paraphrase and you grade
+against the original, you'll catch spec-misread; if you grade against
+the executor's paraphrase, you won't.>
+
+## Acceptance criteria (from the plan, verbatim)
+
+<Verbatim from the ralph plan. If the plan named exact test functions,
+the verifier checks those exact tests exist and pass.>
+
+## Evidence (from `omh_gather_evidence`, run by the orchestrator)
+
+The orchestrator ran the project's actual test/build/lint commands
+BEFORE dispatching you. Real output:
+
+```
+<paste the structured evidence object from omh_gather_evidence:
+results, all_pass, summary>
+```
+
+Do NOT re-run evidence yourself. The orchestrator-runs-evidence pattern
+exists so verifiers see ground truth, not executor claims. If you
+think evidence is incomplete (e.g., wrong test scope, missing
+project), say so in your verdict — don't paper over by re-running.
+
+## Files to inspect
+
+The executor reported touching:
+- <absolute path>
+- <absolute path>
+
+Read each. Check that:
+- The implementation matches the acceptance criteria (not the
+  executor's prose interpretation).
+- The tests authored are the tests the plan named.
+- Sibling-owned files (listed below) were NOT modified.
+- Commit boundary is clean (no sibling files swept in via `git add -A`).
+
+## Sibling-owned files (must be untouched)
+
+- <absolute path> — owned by Task <M>
+- <absolute path> — owned by Task <K>
+
+If the commit modified any of these, that's a P3 violation (parallel
+boundary breach) AND/OR a P9 violation (commit-hygiene). Flag it.
+
+## Specific load-bearing checks (beyond "tests pass")
+
+These are the things the orchestrator wants explicitly verified —
+checks that go past the test suite into reading the code:
+
+- <Named check 1; e.g., "verify the mismatched-flag check happens
+  BEFORE any filesystem writes — if not, partial-flag invocations
+  corrupt state">
+- <Named check 2; e.g., "verify the function uses
+  `bin/_lineage.classify()` rather than reimplementing the
+  taxonomy">
+- <Named check N>
+
+## Strike categorization (if returning REQUEST_CHANGES)
+
+If the implementation does not meet acceptance criteria, categorize
+the strike for the orchestrator:
+
+1. **TEST-INFRA** — the test itself is buggy (fixture race, hash
+   collision in tmpdir naming, runner config issue). Implementation
+   may be correct.
+2. **SPEC-MISREAD** — the executor implemented something different
+   from the acceptance criteria. Cite the specific drift.
+3. **IMPLEMENTATION-BUG** — the executor implemented the right thing
+   but it has a real defect. Name the failing case (input/scenario).
+
+The 3-strike circuit breaker fires on the same `(category, error_key)`
+repeating. Tagging correctly prevents test-infra strikes from masking
+real bugs.
+
+## Output expected back to the orchestrator
+
+A verdict with:
+
+- **Verdict:** APPROVE / REQUEST_CHANGES
+- **Acceptance criteria compliance:** for each criterion, PASS / FAIL
+  with a one-line citation (test name + result, or file:line + observed
+  behavior).
+- **Load-bearing checks:** for each, PASS / FAIL with citation.
+- **Sibling boundary:** CLEAN / VIOLATED (name the violations).
+- **Commit hygiene:** CLEAN / FUZZY (name absorbed-but-out-of-scope
+  files).
+- **Strike category (if REQUEST_CHANGES):** TEST-INFRA / SPEC-MISREAD
+  / IMPLEMENTATION-BUG.
+- **Error key (if REQUEST_CHANGES):** short stable handle the
+  orchestrator can use to detect repetition (e.g.,
+  `hash-collision-in-tmpdir-naming`, `mismatched-flag-write-before-check`).
+- **Specific feedback:** what the executor needs to do differently on
+  retry. Be concrete; vague feedback produces vague retries.
+```
+
+## Key things to include EVERY time
+
+- **The acceptance criteria verbatim from the plan,** not the
+  executor's report. Verifier's job is to grade against the spec.
+- **Real evidence output** from `omh_gather_evidence`. Without it,
+  verifier reads only the executor's claims.
+- **Sibling-owned file list.** Without it, the verifier can't catch
+  P3 (parallel boundary) violations.
+- **Specific load-bearing checks.** "Tests pass" is necessary but not
+  sufficient — the orchestrator names the deeper checks.
+- **Strike-category instruction.** Without categorization, the
+  3-strike breaker fires wrong.
+
+## Variations
+
+- **Re-verify after retry:** add at top:
+  ```
+  ## Prior verdict: REQUEST_CHANGES — <category>
+
+  Prior feedback: <verbatim>. Confirm whether the retry addresses
+  this specific feedback. If yes → APPROVE. If partial → still
+  REQUEST_CHANGES with what remains.
+  ```
+- **Solo task (no parallel siblings):** drop the "Sibling-owned" and
+  "Sibling boundary" sections. KEEP the commit-hygiene check — the
+  working tree may have untracked files from prior orchestrator work.
+- **Test-infra-suspected verifier:** the orchestrator may already
+  suspect a test-infra issue. Tell the verifier:
+  ```
+  ## Test-infra hypothesis
+
+  The orchestrator suspects this failure may be test-infra rather
+  than implementation. Specifically: <hypothesis>. Confirm or refute
+  before grading the implementation.
+  ```
+
+## On the verifier's altitude
+
+The verifier is NOT an executor. Do not try to "fix" what you find;
+report it. The orchestrator decides retry-vs-advance based on your
+verdict + strike category. A verifier who patches things they find
+wrong has collapsed the loop's separation-of-concerns and produces
+unreviewed code.
+
+## Worked verdict example (APPROVE shape)
+
+```
+**Verdict:** APPROVE
+
+**Acceptance criteria compliance:**
+- `test_provision_writes_v1_lineage` — PASS (test_janus_new_being_lineage.py:42)
+- MANIFEST contains content hashes for SOUL.md and template tree —
+  PASS (verified at .janus/seed-history/v1/MANIFEST:1-12)
+- gh_config written when --with-gh — PASS (test_janus_new_being_lineage.py:78)
+
+**Load-bearing checks:**
+- Mismatched-flag check happens before fs writes — PASS
+  (bin/janus-new-being:142, write at :158)
+- Reuses bin/_lineage.classify() — PASS (bin/janus-new-being:131)
+
+**Sibling boundary:** CLEAN
+**Commit hygiene:** CLEAN
+
+No follow-ups.
+```
+
+## Worked verdict example (REQUEST_CHANGES shape)
+
+```
+**Verdict:** REQUEST_CHANGES
+
+**Acceptance criteria compliance:**
+- `test_mismatched_flags_no_partial_writes` — FAIL
+  (test_janus_new_being_lineage.py:104, AssertionError: profile dir
+  contains partial state after mismatched-flag invocation)
+
+**Strike category:** IMPLEMENTATION-BUG
+**Error key:** mismatched-flag-write-before-check
+
+**Specific feedback:**
+The mismatched-flag check at bin/janus-new-being:142 happens AFTER
+the first filesystem write at :128 (the SOUL.md template render).
+Move the check to before any write — the acceptance criterion
+requires partial-flag invocations to leave the filesystem
+unchanged. Test at :104 reproduces.
+
+**Sibling boundary:** CLEAN
+**Commit hygiene:** CLEAN
+```


### PR DESCRIPTION
Sibling skill to `omh-ralplan-orchestration` for the verified-execution loop.

## What this lands

`plugins/omh/skills/omh-ralph-driving/`:

- `SKILL.md` — 5-step playbook + P1–P10 pitfalls + worked example (2026-04-27 janus migration: 13 tasks, 5 iterations, 1 strike, APPROVE_WITH_PROVISO).
- `references/executor-goal-template.md` — full `delegate_task` `goal` shape for executor dispatch: project root, task verbatim, acceptance criteria verbatim, files-owned + DO-NOT-modify (P3), forward-encoded learnings (P4), TDD instruction, explicit `git add` discipline (P9), retry variations per strike category (P5).
- `references/verifier-goal-template.md` — verifier dispatch shape: acceptance-criteria-verbatim grading, evidence paste from `omh_gather_evidence` (P6), sibling-boundary checks, strike categorization, worked APPROVE / REQUEST_CHANGES verdicts.
- `references/architect-final-review-template.md` — Step-7 final-merge gate: diff-range walk, end-to-end MV-slice trace, principle-firing audit, three verdicts with calibration guidance, worked APPROVE_WITH_PROVISO and REQUEST_CHANGES examples.

`README.md` updates (mirroring the `omh-ralplan-orchestration` treatment so the new skill is discoverable):

- Skills table row.
- `hermes skills install` command line.
- "Getting Started" decision bullets.

## Why

The skill landed in this repo a few hours ago undocumented and without the `references/` directory its sibling ships. This PR brings it to full parity:

- YAML frontmatter conforms (verified `yaml.safe_load` parses cleanly).
- Same structural shape as `omh-ralplan-orchestration` (5-step playbook, numbered pitfalls, worked example, related-skills cross-refs, do-not-lose section).
- Templates encode the dispatch-context contract that Steps 3/5/7 of `SKILL.md` describe in prose, so future orchestrators don't have to re-derive the shape.

## Sanity

- `uv run --with pytest --with pyyaml python -m pytest plugins/omh/tests/test_init.py` — 5/5 passing.
- `yaml.safe_load` on `SKILL.md` frontmatter — clean.
- All three `references/*.md` files present and reachable from new `SKILL.md` pointers in Steps 3/5/7.

## Commits

- `795aeea` omh-ralph-driving: dispatcher's playbook for verified execution
- `21e9d96` README: surface omh-ralph-driving in skills table, install line, getting-started
