### PR TITLE
omh-triage v0.1: Maintainer + Skeptic worker skill + dispatcher playbook + proxy-pattern docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,64 @@ rm ~/.hermes/plugins/omh ~/.hermes/skills/omh
 
 (Symlinks only — your repo is untouched.)
 
+### Testing pre-merge changes against a worktree (proxy pattern)
+
+When you're working on a multi-commit OMH change in a `git worktree` and want
+to **battle-test it from a live Hermes session before merging to `master`**,
+don't repoint your profile symlinks at the worktree directly. Once-per-flip
+edits across multiple profiles are error-prone and easy to leave in a broken
+state if you forget which profile is pointing where.
+
+Instead, add **one level of indirection**: a per-machine proxy directory
+that profiles always point at, and which you flip in one place to choose
+between `master` and any worktree.
+
+**One-time setup (per machine):**
+
+```bash
+# Stable per-machine proxy location
+mkdir -p ~/.local/share/omh-dev
+
+# Initial target: live master checkout
+ln -sfn /path/to/oh-my-hermes/plugins/omh         ~/.local/share/omh-dev/plugin
+ln -sfn /path/to/oh-my-hermes/plugins/omh/skills  ~/.local/share/omh-dev/skills
+
+# Profile symlinks now point at the proxy, not the repo
+ln -sfn ~/.local/share/omh-dev/plugin  ~/.hermes/plugins/omh
+ln -sfn ~/.local/share/omh-dev/skills  ~/.hermes/skills/omh
+```
+
+**To work against a worktree:**
+
+```bash
+ln -sfn /path/to/oh-my-hermes-<arc>/plugins/omh         ~/.local/share/omh-dev/plugin
+ln -sfn /path/to/oh-my-hermes-<arc>/plugins/omh/skills  ~/.local/share/omh-dev/skills
+```
+
+**To flip back to master:**
+
+```bash
+ln -sfn /path/to/oh-my-hermes/plugins/omh         ~/.local/share/omh-dev/plugin
+ln -sfn /path/to/oh-my-hermes/plugins/omh/skills  ~/.local/share/omh-dev/skills
+```
+
+Why two proxy entries (`plugin/` + `skills/`) instead of one? Because
+profiles symlink them independently — `plugins/omh/` (Python tool/hook code)
+and `skills/omh/` (SKILL.md files) live at sibling paths in the profile.
+Flipping both together keeps them coherent across master/worktree boundaries.
+
+**Why this matters:** OMH ships to real users. Treating `master` as a place
+to "experiment" or "try this and see if it works" risks breaking installs in
+the wild. The proxy pattern lets you battle-test arbitrary worktrees from a
+live session without ever touching `master`'s tip until the work is baked.
+
+> **Cross-machine portability note.** If your profile symlinks live in a git
+> repo that gets exported to other machines (e.g. a forge profile), use
+> *relative* paths from the profile to the proxy:
+> `ln -sfn ../../../../.local/share/omh-dev/plugin <profile>/plugins/omh`.
+> Per-machine proxy contents differ; relative profile→proxy paths stay
+> portable. The proxy itself uses absolute paths since it's never exported.
+
 ## Testing
 
 Plugin tests live in `plugins/omh/tests/`. Run from the repo root:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Skills work standalone with zero dependencies.
 | **omh-deep-interview** | Socratic requirements interview with coverage tracking |
 | **omh-ralph** | Verified execution: implement → verify → iterate until done |
 | **omh-ralph-driving** | Dispatcher's playbook for driving an `omh-ralph` run — plan-shape, parallel batching, evidence gathering, verifier discipline, strike categorization, Step-7 final architect review, commit hygiene |
+| **omh-triage** *(v0.1)* | Multi-role consensus triage of an issue backlog — Maintainer (code-anchored) + Skeptic (pruning); more roles coming after lived rounds. See [witt3rd/oh-my-hermes#9](https://github.com/witt3rd/oh-my-hermes/issues/9) |
+| **omh-triage-orchestration** *(v0.1)* | Dispatcher's playbook for driving an `omh-triage` run — pre-flight backlog audit, role-pass dispatch, distillation, user sign-off gate |
 | **omh-autopilot** | Full pipeline composing all three skills end-to-end |
 
 Composition (recommended pipeline for unfamiliar domains):
@@ -50,6 +52,7 @@ For local development (live edits via symlinks), see [CONTRIBUTING.md](CONTRIBUT
 - **Vague idea?** → `omh-deep-interview` then `omh-ralplan`
 - **Have a plan, need execution?** → `omh-ralph`
 - **Driving a ralph run yourself?** → `omh-ralph-driving` (load alongside `omh-ralph`)
+- **Grooming an issue backlog?** → `omh-triage` (load alongside `omh-triage-orchestration` if you're driving)
 - **End-to-end?** → `omh-autopilot`
 
 OMH self-seeds a `.omh/` directory in the project on first use (with the

--- a/plugins/omh/references/role-triage-maintainer.md
+++ b/plugins/omh/references/role-triage-maintainer.md
@@ -19,8 +19,9 @@ You are not the issue's original author. You are not deciding priority. You are 
 - **live** — still current as written; no body changes needed
 
 You may also produce:
-- **partial-stale** — issue contains multiple sub-claims; some are stale, some are live
+- **partial-stale** — issue contains multiple sub-claims; some are stale, some are live (treated identically to `recast` by the orchestrator's resolution matrix; output should still distinguish so the recast spec can name which sub-claims are stale vs live)
 - **out-of-scope** — issue is real but belongs in a different repo (refile, don't carry)
+- **needs-investigation** — escape hatch when verdict cannot be determined without runtime reproduction or design work; orchestrator escalates to user with a proposed next-step
 
 ## Output format
 
@@ -28,7 +29,7 @@ For each issue assigned to your pass:
 
 ```
 ### #N — <title>
-**Verdict:** stale | recast | live | partial-stale | out-of-scope
+**Verdict:** stale | recast | live | partial-stale | out-of-scope | needs-investigation
 **Anchored to:** <commit-ref> | <file:line> | <test-name>
 **Reasoning:** <one paragraph; what the issue claimed, what current code shows, why the verdict>
 **If stale:** <pointer-comment text suitable for posting on close>
@@ -45,6 +46,6 @@ For each issue assigned to your pass:
 
 ## When you cannot complete a verdict
 
-If verifying the issue requires reproducing a runtime bug, designing a fix, or deciding priority — out of scope for your role. Mark "needs investigation" and name what the next role (or the user) needs to determine.
+If verifying the issue requires reproducing a runtime bug, designing a fix, or deciding priority — out of scope for your role. Return verdict **needs-investigation** and name what the next role (or the user) needs to determine.
 
 Your job ends at verdict. You do not assign priority, target version, cluster, or size.

--- a/plugins/omh/references/role-triage-maintainer.md
+++ b/plugins/omh/references/role-triage-maintainer.md
@@ -1,0 +1,50 @@
+# Role: Triage Maintainer
+
+You are a senior maintainer of the codebase under triage. Your job is to **vet each issue against current code** and produce a disposition verdict that a future reader can verify mechanically.
+
+You are not the issue's original author. You are not deciding priority. You are answering one question per issue: **does the premise of this issue still hold against the code as it exists today?**
+
+## Your responsibilities
+
+- Read each issue against repo HEAD, not against label assumptions
+- For each surface the issue names (file path, binary, tool, function, schema field), verify it still exists as described
+- Identify supersession: has a recent commit, migration, or refactor moved the underlying premise?
+- Identify recast-needed: is the premise still valid but the body references deleted surfaces?
+- Cite ground truth: every verdict must reference a commit ref, file:line, or test that proves the claim
+
+## Verdict types
+
+- **stale** — premise has moved; recommend close with pointer to what superseded it
+- **recast** — premise still valid; body references deleted surfaces and needs surgery
+- **live** — still current as written; no body changes needed
+
+You may also produce:
+- **partial-stale** — issue contains multiple sub-claims; some are stale, some are live
+- **out-of-scope** — issue is real but belongs in a different repo (refile, don't carry)
+
+## Output format
+
+For each issue assigned to your pass:
+
+```
+### #N — <title>
+**Verdict:** stale | recast | live | partial-stale | out-of-scope
+**Anchored to:** <commit-ref> | <file:line> | <test-name>
+**Reasoning:** <one paragraph; what the issue claimed, what current code shows, why the verdict>
+**If stale:** <pointer-comment text suitable for posting on close>
+**If recast:** <specific body surgery — what to delete, what to add, what stays>
+```
+
+## Principles
+
+- **Code is ground truth, not labels.** A `priority/0` label is irrelevant if the surface the issue gates is deleted.
+- **Cite or stay silent.** If you cannot anchor a claim to a commit or path, mark it "anchored to: needs investigation" rather than guessing.
+- **Be specific about what moved.** "Done in v6" is weak; "Done in v6 (commit `c49abbf`); see `tests/test_legacy_retirement.py`" is the standard.
+- **Don't second-guess intent.** If the issue's premise is genuinely live, mark it live even if you'd write a different issue.
+- **Refile, don't recast across repos.** If an issue's bug-class is real but the repro surface is in another repo, mark out-of-scope and name the target repo.
+
+## When you cannot complete a verdict
+
+If verifying the issue requires reproducing a runtime bug, designing a fix, or deciding priority — out of scope for your role. Mark "needs investigation" and name what the next role (or the user) needs to determine.
+
+Your job ends at verdict. You do not assign priority, target version, cluster, or size.

--- a/plugins/omh/references/role-triage-skeptic.md
+++ b/plugins/omh/references/role-triage-skeptic.md
@@ -1,0 +1,60 @@
+# Role: Triage Skeptic
+
+You are an adversarial reviewer of the issue backlog. Your job is to **prune** — to challenge each issue's right to a slot in the queue.
+
+You are not anti-feature. You are anti-accumulation. The backlog is a finite cognitive surface. Every issue that survives consumes attention every grooming round, every release-cut, every onboarding read. Issues that don't earn their slot quietly degrade the backlog's usefulness as a working tool.
+
+You are also not the Maintainer. The Maintainer asks "is the premise live?" — you ask "even if it's live, does it deserve to be open?"
+
+## Your responsibilities
+
+- Challenge each live or recast issue with the question: **why is this still open?**
+- Identify drop candidates: issues filed because filing was easy, not because the underlying friction was load-bearing
+- Identify duplicate or near-duplicate issues that can be consolidated
+- Identify issues whose described pain has not been re-encountered since filing (the "filed once, never recurred" pattern)
+- Identify issues that have grown stale not because code moved, but because *the team's understanding* moved (the issue describes a problem the team no longer thinks is a problem)
+- Identify issues that should be **refiled smaller** — where the original framing bundles too many concerns and a tighter version would be more actionable
+
+## Skeptical techniques
+
+1. **Recurrence test.** When was this last lived through? If the answer is "filed once N months ago, never re-felt," challenge.
+2. **Consolidation test.** Is there another open issue covering the same underlying friction? If yes, recommend dedup.
+3. **Smaller-form test.** Could a 2-sentence issue replace this 500-word one without loss? If yes, recommend refile-smaller.
+4. **Inversion test.** What would change if we closed this and never addressed it? If "nothing observable," challenge.
+5. **Filed-because-easy test.** Was this issue filed *during* a session where it surfaced organically, or filed in a sweep "just to capture the thought"? Capture-sweep issues age worse.
+
+## Verdict types
+
+- **keep** — issue earns its slot; reasoning given
+- **drop** — issue should be closed without addressing (with pointer-comment explaining why-not)
+- **dedup** — issue is covered by another (name the other issue)
+- **refile-smaller** — issue should be closed and reopened in tighter form (name the tighter form)
+- **wait-for-recurrence** — close pending re-occurrence; reopen automatically if the underlying friction is felt again
+
+## Output format
+
+For each issue assigned to your pass:
+
+```
+### #N — <title>
+**Skeptical verdict:** keep | drop | dedup | refile-smaller | wait-for-recurrence
+**Pressure applied:** <which skeptical technique surfaced the verdict>
+**Reasoning:** <one paragraph; what would be lost if this were dropped>
+**If drop/wait:** <pointer-comment for the close>
+**If dedup:** <name the covering issue>
+**If refile-smaller:** <draft of the tighter form>
+```
+
+## Principles
+
+- **The default is drop.** An issue must earn its slot; existence is not earning.
+- **Be honest about uncertainty.** If you genuinely don't know whether dropping costs anything, say so — don't manufacture certainty in either direction.
+- **Closing is reversible.** A dropped issue can be refiled if the friction recurs. A kept issue accumulates cognitive weight every grooming round forever.
+- **Respect lived friction.** An issue tagged `source/lived-friction` (i.e. surfaced from a real session, not from a stance reading or a recon doc) gets stronger weight against drop. Lived friction ≠ imagined friction.
+- **Don't be hostile.** Your job is to apply pressure, not to tear down. If keep is the right verdict, say so cleanly.
+
+## When you cannot complete a verdict
+
+If determining drop-vs-keep requires lived-use evidence the backlog doesn't have — mark "needs lived signal" and propose a tripwire (e.g., "reopen if recur"). Don't guess.
+
+Your job ends at the skeptical verdict. You do not anchor against code (that's Maintainer), assign priority/version (that's Operator/Architect, not yet introduced), or execute closes.

--- a/plugins/omh/references/role-triage-skeptic.md
+++ b/plugins/omh/references/role-triage-skeptic.md
@@ -30,6 +30,7 @@ You are also not the Maintainer. The Maintainer asks "is the premise live?" — 
 - **dedup** — issue is covered by another (name the other issue)
 - **refile-smaller** — issue should be closed and reopened in tighter form (name the tighter form)
 - **wait-for-recurrence** — close pending re-occurrence; reopen automatically if the underlying friction is felt again
+- **needs-lived-signal** — escape hatch when verdict cannot be determined from backlog alone; orchestrator escalates to user with a proposed tripwire
 
 ## Output format
 
@@ -37,7 +38,7 @@ For each issue assigned to your pass:
 
 ```
 ### #N — <title>
-**Skeptical verdict:** keep | drop | dedup | refile-smaller | wait-for-recurrence
+**Skeptical verdict:** keep | drop | dedup | refile-smaller | wait-for-recurrence | needs-lived-signal
 **Pressure applied:** <which skeptical technique surfaced the verdict>
 **Reasoning:** <one paragraph; what would be lost if this were dropped>
 **If drop/wait:** <pointer-comment for the close>
@@ -55,6 +56,6 @@ For each issue assigned to your pass:
 
 ## When you cannot complete a verdict
 
-If determining drop-vs-keep requires lived-use evidence the backlog doesn't have — mark "needs lived signal" and propose a tripwire (e.g., "reopen if recur"). Don't guess.
+If determining drop-vs-keep requires lived-use evidence the backlog doesn't have — return verdict **needs-lived-signal** and propose a tripwire (e.g., "reopen if the friction recurs in any session"). The orchestrator will escalate to user. Don't guess.
 
 Your job ends at the skeptical verdict. You do not anchor against code (that's Maintainer), assign priority/version (that's Operator/Architect, not yet introduced), or execute closes.

--- a/plugins/omh/skills/omh-triage-orchestration/SKILL.md
+++ b/plugins/omh/skills/omh-triage-orchestration/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: omh-triage-orchestration
+description: "Dispatcher's playbook for omh-triage runs (when to invoke, how to drive)"
+version: 0.1.0
+metadata:
+  hermes:
+    tags: [triage, orchestration, dispatcher, multi-agent]
+    category: omh
+    requires_toolsets: [terminal, omh, delegation]
+---
+
+# OMH Triage Orchestration — Driving a Triage Run
+
+> **v0.1 status:** Like the worker skill (`omh-triage`), this dispatcher's playbook is deliberately small. Pitfalls accumulate through lived rounds. The `omh-ralplan-orchestration` skill is the structural model — that one shipped to 25 numbered pitfalls only after multiple real runs surfaced each failure mode. This one starts at T1–T6 and grows.
+
+## When You Are the Orchestrator
+
+You are the orchestrator if you are dispatching `omh-triage` against a backlog and intending to land verdicts (closures, recasts, version targeting) on real issues.
+
+You are not the orchestrator if you are running `omh-triage` as an experiment to see what the skill produces (no execution intent). For experiments, skip the user sign-off gate and just observe — but mark the run as exploratory in any output doc.
+
+## Pre-flight Discipline
+
+Before invoking `omh-triage`:
+
+### Audit the backlog state
+
+1. **Issue count.** If <10 open issues, you probably don't need triage; just decide manually. If >100 open issues, the backlog has rotted; do a manual first-pass cull before invoking.
+2. **Time since last grooming.** If <2 weeks AND no major refactor landed, may not be worth a round.
+3. **Project board state** (if any). Cards in "Won't ship" / staging columns should be drained by a triage round, not left to accumulate.
+4. **Recent migrations or refactors.** This is the load-bearing pre-flight check — *what surfaces have moved since issues were filed?* If the answer is "many," triage is high-leverage. If the answer is "none," triage is low-leverage.
+
+### Audit the **trigger**
+
+What's the actual reason for this run?
+
+- "About to cut version vN+1, want to know what's in scope" → triage will inform version-cut planning. Output should target the project's version field.
+- "Just shipped a major migration, several issues may be stale" → triage is a cleanup pass. Output is mostly closures.
+- "Backlog feels heavy, want to prune" → Skeptic's pressure dominates; Maintainer is supporting. Frame the goal accordingly.
+- "Periodic hygiene, no specific motivator" → low-priority; consider deferring until a triggering reason exists.
+
+The trigger shapes how you weight the role outputs. A cleanup-pass run weights Maintainer; a pruning run weights Skeptic.
+
+### Audit the host project's discipline
+
+Does the host project have:
+- A `docs/triage/PROCESS.md` documenting two-mode discipline (quick-file vs grooming)?
+- A GitHub Project with target-version + cluster fields?
+- A prior triage doc to delta against?
+
+If not, propose authoring these first — `omh-triage` produces dated docs and project-board updates; if there's no infrastructure to write them into, the output evaporates.
+
+## The dispatcher's job during the run
+
+### During Phase 0 (context gathering)
+
+You author the context package, not a subagent. The package shapes both subagents' work; getting it wrong wastes both passes.
+
+The package must include:
+- Repo HEAD ref (the anchor for Maintainer's vetting)
+- List of recent migrations / refactors with brief description (so Maintainer doesn't re-derive)
+- Issue count + label distribution + age distribution
+- Prior triage doc summary (if any), specifically: what verdicts landed, what was deferred
+- The trigger framing (cleanup vs pruning vs hygiene)
+
+If the package is over ~1000 words, it's bloated. ~500 is the target.
+
+### During Phase 1 (role passes)
+
+Maintainer first; Skeptic only on Maintainer's live + recast output. Don't run them parallel-from-scratch — the Skeptic needs Maintainer's verdicts to know what to review.
+
+Watch for these failure modes (each becomes a numbered pitfall as it's lived):
+
+- **T1 — Maintainer claims "stale" without a commit ref.** Reject and request anchor. "Done in a recent migration" is not a valid anchor; "Done in v6 (commit `c49abbf`)" is.
+- **T2 — Skeptic reviews stale issues.** A waste-of-pass. The skill body says skip them, but if the dispatcher passes the wrong inventory to Skeptic, this happens.
+- **T3 — Subagent produces a flat narrative instead of per-issue blocks.** The skill's output format is structured for a reason — distillation depends on per-issue parsing. Reject and request structured output.
+
+### During Phase 2 (distillation)
+
+You — the orchestrator — produce the resolution table per the skill's verdict-combination matrix. Conflicts go to user, not auto-resolved. Be specific about *which* issues are conflicts; "there are some conflicts" is not enough.
+
+If the round produced **no conflicts**, that's worth noting. Either the role pressures are well-aligned this round (good) or the roles haven't pressed hard enough (bad). After several rounds with zero conflicts, it's time to add a third role.
+
+### During Phase 3 (execution)
+
+User-gated. Execute closures, recasts, board updates. Use the `/tmp/closeN.md` + shell-loop idiom for the actual close commands (not `terminal()` from `execute_code` — multi-paragraph quoted bodies fail silently there; learned in janus round 1).
+
+After execution, write the round doc. The doc names what you did, what you deferred, and what the round *taught* — lessons that may want to fold back into PROCESS.md or this skill if subsequent rounds confirm them.
+
+## Pitfalls (v0.1)
+
+### T1 — Skipping ground-truth pre-flight
+
+The dispatcher's biggest leverage is Phase 0. A run with bad ground truth produces stale verdicts that look authoritative because they came from a multi-role consensus. The discipline: spend 10 minutes mapping recent migrations *before* dispatching anyone.
+
+### T2 — Authoring the triage doc before the run
+
+Don't write your verdicts into the doc and then run `omh-triage` to "validate" them. The roles' job is to surface what the dispatcher missed; if the dispatcher already decided, the roles are theater. Write the doc *from* the run output, not *toward* it.
+
+### T3 — Letting the run grow scope
+
+A grooming round has a defined scope: the open issues at the time of the run. If a role surfaces "we should also redesign X" — that's a separate ralplan, not part of triage. Note it in the round doc's "deferred" section; don't try to handle it in-loop.
+
+### T4 — Treating the close pile as low-attention
+
+Closures are durable. A wrongly-closed issue is much harder to recover than a wrongly-kept one. Read every pointer-comment before posting, even when the role's verdict feels clear. The Maintainer's "stale" verdict is your verdict to ratify, not to rubber-stamp.
+
+### T5 — Conflicts presented as questions, not as decisions
+
+When the roles disagree, your distillation should produce a **specific decision question for the user** — not a generic "there's some disagreement on these N issues." Frame each conflict as: "Maintainer says X for reason A; Skeptic says Y for reason B; my recommendation is Z." Then ask. (See `omh-ralplan-orchestration` P25 — skepticism over deference.)
+
+### T6 — Running too often
+
+Grooming is not a daily activity. If you find yourself dispatching `omh-triage` weekly, the underlying problem is more issues are filed than the team is willing to act on; the fix is upstream (better filing discipline, smaller backlog, fewer new issues), not more triage.
+
+## Templates
+
+- `plugins/omh/skills/omh-triage/references/triage-doc-template.md` — structure for the round doc
+- `plugins/omh/skills/omh-triage/references/orchestrator-review-template.md` — pre-execution review by you
+
+## Pairs With
+
+- `omh-triage` — the worker skill
+- `omh-ralplan-orchestration` — the structural model this followed
+- The host project's `docs/triage/PROCESS.md` if one exists (defines the two-mode quick-file/grooming discipline that triage runs *within*)

--- a/plugins/omh/skills/omh-triage/SKILL.md
+++ b/plugins/omh/skills/omh-triage/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: omh-triage
+description: "Multi-role consensus triage of an issue backlog (v0.1: Maintainer + Skeptic)"
+version: 0.1.0
+metadata:
+  hermes:
+    tags: [triage, multi-agent, consensus, backlog]
+    category: omh
+    requires_toolsets: [terminal, omh, delegation]
+---
+
+# OMH Triage — Consensus Backlog Grooming
+
+> **v0.1 status:** This skill is **deliberately small**. It ships with two roles (Maintainer, Skeptic) and is being battle-tested before more roles are added. The full design hypothesis (Maintainer / Operator / Architect / Member-advocate / Skeptic) lives in [witt3rd/oh-my-hermes#9](https://github.com/witt3rd/oh-my-hermes/issues/9). Roles will be added as lived rounds surface real tensions that the current set cannot represent. The discipline here is *learn through use, then expand* — the inverse of authoring all five roles up-front against imagined friction.
+
+## When to Use
+
+- Periodically grooming an issue backlog (default cadence: before each version cut, when ≥10 issues have accumulated since the last pass, or when a major refactor/migration just landed and may have moved issue premises)
+- After a fast-moving development arc (multiple migrations or refactors in days/weeks) that may have superseded several open issues
+- When the user says: "triage", "groom the backlog", "walk the issues", "what's stale"
+
+## When NOT to Use
+
+- A single ambiguous issue that needs design (use `omh-deep-interview` then `omh-ralplan`)
+- A backlog that's never been groomed and has hundreds of issues (do a manual first-pass cull first; this skill is for keeping a curated backlog honest, not for archaeology on a rotted one)
+- Closing during active dev (don't mix the two-mode discipline — capture during dev, decide during grooming; see the host project's `docs/triage/PROCESS.md` if it has one)
+
+## Prerequisites
+
+- A target repo with an issue backlog (GitHub Issues; pluggable for other backlogs eventually)
+- Optional: a GitHub Project for version + cluster + status targeting (the run will write back to it)
+- Optional: prior triage docs under `docs/triage/` for delta-since-last-pass framing
+- The `delegate_task` tool must be available
+
+## Procedure
+
+### Phase 0: Ground-truth pre-flight
+
+Before dispatching any roles, the orchestrator gathers:
+
+1. **Repo HEAD.** Note the commit ref. Verdicts will anchor against this.
+2. **Issue inventory.** `gh issue list --state open --limit <N>`. Note count, label distribution, age distribution.
+3. **Recent migrations / refactors.** Read commit log for the last N weeks. The orchestrator must know what surfaces have moved before dispatching — otherwise the Maintainer will discover this in-flight and waste a round.
+4. **Existing project board state** (if any). Read target version, cluster, status fields for context.
+5. **Prior triage doc** (if any). The most recent `docs/triage/YYYY-MM-DD-*.md` is delta-since-last-pass anchor.
+
+Phase 0's output is a ~500-word context package that all subagents will receive. Same shape as `omh-ralplan` Phase 0.
+
+### Phase 1: Role passes (sequential, parallel where possible)
+
+**v0.1 ships two roles.** Future versions will add Operator, Architect, Member-advocate.
+
+#### Step 1 — Maintainer pass
+
+```
+delegate_task(
+    goal="[omh-role:triage-maintainer] Vet each issue in the attached inventory against current code. Produce a per-issue verdict (stale/recast/live/partial-stale/out-of-scope) with code-anchored reasoning. Repo HEAD: <ref>. Inventory: <list>",
+    context="# Project context\n\n<context-package>\n\n# Inventory\n\n<full issue bodies, not just titles>"
+)
+```
+
+The Maintainer's pass is **per-issue**. Output is structured (one block per issue with verdict + anchor + reasoning + close-comment-or-recast-spec).
+
+#### Step 2 — Skeptic pass (parallel with Maintainer if the queue is large; sequential if small)
+
+```
+delegate_task(
+    goal="[omh-role:triage-skeptic] For each LIVE issue from the Maintainer pass, apply skeptical pressure: keep/drop/dedup/refile-smaller/wait-for-recurrence. Stale/out-of-scope issues do not need skeptical review.",
+    context="# Project context\n\n<context-package>\n\n# Maintainer verdicts\n\n<Maintainer's structured output>\n\n# Full inventory (for cross-reference)\n\n<full issue bodies>"
+)
+```
+
+The Skeptic only reviews issues the Maintainer marked live or recast. Stale/out-of-scope are already moving to close; double-pressure on them wastes the role's attention.
+
+#### Step 3 — Orchestrator distillation
+
+The orchestrator combines Maintainer + Skeptic verdicts:
+
+| Maintainer | Skeptic | Resolved disposition |
+|------------|---------|----------------------|
+| stale | (not run) | close — Maintainer pointer-comment |
+| out-of-scope | (not run) | close — refile-target named |
+| recast | keep | recast body, keep open |
+| recast | drop / wait-for-recurrence | close (Skeptic outweighs — the body needs work AND the underlying friction may not be load-bearing) |
+| recast | refile-smaller | close + reopen-as-smaller |
+| live | keep | live |
+| live | drop / wait-for-recurrence | close — Skeptic pointer-comment |
+| live | dedup | close + comment-on-covering-issue |
+| live | refile-smaller | close + reopen-as-smaller |
+
+Conflicts (Maintainer says recast/live, Skeptic says drop) get **escalated to user**, not auto-resolved. The orchestrator's job is to distill, not to decide for the user.
+
+### Phase 2: Output
+
+The orchestrator produces:
+
+1. **Triage doc** at `docs/triage/YYYY-MM-DD-<descriptor>.md` (in the host repo, not in this skill repo) using the host project's template. If no template exists, use the structure documented in `references/triage-doc-template.md`.
+2. **Verdict execution plan** — list of closures (with body files staged at `/tmp/closeN.md`), recasts (with proposed body diffs), refile-smaller drafts.
+3. **Project board updates** (if a project is configured) — target-version moves, cluster updates, status changes.
+
+The orchestrator **stages, does not execute** by default. The user sign-off gate happens between Phase 2 and execution. See `references/orchestrator-review-template.md`.
+
+### Phase 3: Execution (user-gated)
+
+After user approval:
+
+1. Post pointer-comments and close stale/dropped issues
+2. Post recast PRs (or comments with proposed body changes)
+3. Update project board fields
+4. Commit the triage doc with appropriate authorship
+
+## Roles in v0.1
+
+| Role | Reference | Pressure |
+|------|-----------|----------|
+| Triage Maintainer | `references/role-triage-maintainer.md` | Code-anchored ground truth: is the premise live? |
+| Triage Skeptic | `references/role-triage-skeptic.md` | Pruning: does this earn its slot? |
+
+Roles **planned for v0.2+** (witt3rd/oh-my-hermes#9):
+
+- **Operator** — version-cut planning: smallest defensible vN+1
+- **Architect** — cross-cutting: which issues are symptoms of one root
+- **Member-advocate** — lived experience: what hurts the user/principal/being now
+
+These will be added when lived rounds surface tensions the current two cannot represent. Resist authoring them ahead of evidence.
+
+## Output Quality Bar
+
+A run is done when:
+
+1. Every open issue has a Maintainer verdict (no skipped issues)
+2. Every live/recast issue has a Skeptic verdict
+3. Every stale/dropped issue has a pointer-comment ready to post
+4. Every recast issue has a specific body-surgery spec (not "rewrite the body")
+5. Conflicts are escalated to user, not silently resolved
+6. The triage doc names what this round did NOT do (deferred work)
+
+## Pitfalls (v0.1, will grow)
+
+### T1 — Don't dispatch Maintainer without ground-truth Phase 0
+
+Maintainer's job is to anchor against current code. If the orchestrator hasn't already mapped recent migrations/refactors, the Maintainer discovers them in-flight and wastes attention re-deriving what Phase 0 should have given.
+
+### T2 — Skeptic only reviews live + recast
+
+Issues the Maintainer marked stale or out-of-scope are already moving to close. Sending them to Skeptic produces noise (Skeptic will say "drop" on stale issues, which adds nothing).
+
+### T3 — Stage, don't execute by default
+
+Triage closes are durable on the issue tracker. Always stage closures with body files at `/tmp/closeN.md` and let the user approve before executing the actual close commands. The skill that runs the close after approval should loop in shell with `--comment "$(cat /tmp/closeN.md)"` (multi-paragraph quoted bodies through `terminal()` from `execute_code` fail silently — lesson from janus round 1).
+
+### T4 — Conflicts escalate, never auto-resolve
+
+If Maintainer says "live, body is fine" and Skeptic says "drop, never recurred" — that's a real disagreement about whether the issue earns its slot. Surface to user; don't pick one role's verdict.
+
+### T5 — A round produces a durable doc
+
+The triage doc under `docs/triage/YYYY-MM-DD-*.md` is the round's audit trail. It names what was decided, what was deferred, and what the round taught. A round without a doc didn't happen.
+
+### T6 — Resist the pressure to ship missing roles up-front
+
+This skill is v0.1 deliberately. The OMH#9 design names five roles; only two ship today. Adding Operator / Architect / Member-advocate before lived rounds surface real tensions for them is the "imagined friction" failure mode. Wait for evidence.
+
+## Pairs With
+
+- `omh-triage-orchestration` — the dispatcher's playbook (when to invoke, how to drive, what good output looks like)
+- `omh-ralplan-orchestration` — analogous skill for the design layer; the discipline patterns are similar
+- `omh-deep-interview` — for ambiguous issues that need clarification before triage can decide
+
+## See Also
+
+- [`witt3rd/oh-my-hermes#9`](https://github.com/witt3rd/oh-my-hermes/issues/9) — design tracking issue
+- `references/role-triage-maintainer.md`
+- `references/role-triage-skeptic.md`

--- a/plugins/omh/skills/omh-triage/SKILL.md
+++ b/plugins/omh/skills/omh-triage/SKILL.md
@@ -61,7 +61,7 @@ delegate_task(
 
 The Maintainer's pass is **per-issue**. Output is structured (one block per issue with verdict + anchor + reasoning + close-comment-or-recast-spec).
 
-#### Step 2 — Skeptic pass (parallel with Maintainer if the queue is large; sequential if small)
+#### Step 2 — Skeptic pass (after Maintainer; needs Maintainer's verdicts as input)
 
 ```
 delegate_task(
@@ -74,21 +74,26 @@ The Skeptic only reviews issues the Maintainer marked live or recast. Stale/out-
 
 #### Step 3 — Orchestrator distillation
 
-The orchestrator combines Maintainer + Skeptic verdicts:
+The orchestrator combines Maintainer + Skeptic verdicts. **The matrix below is authoritative** — every Maintainer × Skeptic combination resolves to a specific disposition. Combinations not enumerated here are the only cases that escalate to user as a true conflict.
+
+The Maintainer verdict `partial-stale` (issue contains multiple sub-claims; some stale, some live) is treated identically to `recast` for matrix purposes — both signal "body needs surgery, possibly extensive." Maintainer output should still distinguish them so the recast spec can name which sub-claims are stale vs live, but the disposition resolution is the same.
 
 | Maintainer | Skeptic | Resolved disposition |
 |------------|---------|----------------------|
 | stale | (not run) | close — Maintainer pointer-comment |
 | out-of-scope | (not run) | close — refile-target named |
-| recast | keep | recast body, keep open |
-| recast | drop / wait-for-recurrence | close (Skeptic outweighs — the body needs work AND the underlying friction may not be load-bearing) |
-| recast | refile-smaller | close + reopen-as-smaller |
+| recast / partial-stale | keep | recast body, keep open |
+| recast / partial-stale | drop / wait-for-recurrence | close — Skeptic pointer-comment (the body needs work AND the underlying friction may not be load-bearing; combined verdict is "not worth the surgery") |
+| recast / partial-stale | dedup | close + comment-on-covering-issue |
+| recast / partial-stale | refile-smaller | close + reopen-as-smaller |
 | live | keep | live |
 | live | drop / wait-for-recurrence | close — Skeptic pointer-comment |
 | live | dedup | close + comment-on-covering-issue |
 | live | refile-smaller | close + reopen-as-smaller |
 
-Conflicts (Maintainer says recast/live, Skeptic says drop) get **escalated to user**, not auto-resolved. The orchestrator's job is to distill, not to decide for the user.
+The matrix is exhaustive over the verdict types in this skill (v0.1). When future versions add roles or new verdict types, the matrix expands; conflicts surface only when a *new* combination doesn't have a resolution.
+
+**The escalation case** (rare in v0.1): if a Skeptic returns `needs lived signal` (the role's escape hatch when verdict cannot be determined) — or any other unresolved value the role catalog doesn't enumerate — that's a true escalation. The orchestrator surfaces these to user as specific decision questions. The orchestrator's job is to distill, not to decide for the user when the matrix doesn't resolve.
 
 ### Phase 2: Output
 
@@ -149,9 +154,13 @@ Issues the Maintainer marked stale or out-of-scope are already moving to close. 
 
 Triage closes are durable on the issue tracker. Always stage closures with body files at `/tmp/closeN.md` and let the user approve before executing the actual close commands. The skill that runs the close after approval should loop in shell with `--comment "$(cat /tmp/closeN.md)"` (multi-paragraph quoted bodies through `terminal()` from `execute_code` fail silently — lesson from janus round 1).
 
-### T4 — Conflicts escalate, never auto-resolve
+### T4 — The matrix resolves; only un-enumerated cases escalate
 
-If Maintainer says "live, body is fine" and Skeptic says "drop, never recurred" — that's a real disagreement about whether the issue earns its slot. Surface to user; don't pick one role's verdict.
+The verdict-combination matrix in Phase 1 Step 3 is **authoritative** — `live` + `drop` resolves to "close — Skeptic pointer-comment", not to "user conflict." The matrix encodes our considered judgment that "Maintainer says live, Skeptic says drop" means *the issue is real but not worth the slot it consumes*; closing with a clear pointer-comment that invites refile-on-recurrence is the correct disposition, not a user-decision question.
+
+True escalations are: the Skeptic returns `needs lived signal` (escape hatch), the Maintainer returns `needs investigation` (escape hatch), or some future role's verdict produces a combination the matrix doesn't enumerate. These are rare in v0.1 and surface to user as specific decision questions, not as "there are some conflicts."
+
+The dispatcher should also feel free to **override the matrix** for individual issues when their own bar applied to the verdict produces a different read — but that's a dispatcher-judgment call, not a matrix conflict. Note overrides explicitly in the orchestrator review (`omh-ralplan-orchestration` P25 — skepticism over deference applies here too).
 
 ### T5 — A round produces a durable doc
 

--- a/plugins/omh/skills/omh-triage/SKILL.md
+++ b/plugins/omh/skills/omh-triage/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 # OMH Triage — Consensus Backlog Grooming
 
-> **v0.1 status:** This skill is **deliberately small**. It ships with two roles (Maintainer, Skeptic) and is being battle-tested before more roles are added. The full design hypothesis (Maintainer / Operator / Architect / Member-advocate / Skeptic) lives in [witt3rd/oh-my-hermes#9](https://github.com/witt3rd/oh-my-hermes/issues/9). Roles will be added as lived rounds surface real tensions that the current set cannot represent. The discipline here is *learn through use, then expand* — the inverse of authoring all five roles up-front against imagined friction.
+> **v0.1 status:** This skill is **deliberately small**. It ships with two roles (Maintainer, Skeptic) and is being battle-tested before more roles are added. The full design hypothesis (Maintainer / Operator / Architect / Member-advocate / Skeptic) lives in [witt3rd/oh-my-hermes#9](https://github.com/witt3rd/oh-my-hermes/issues/9). The next concrete milestone (Operator role for version-cut planning pressure) is tracked at [witt3rd/oh-my-hermes#11](https://github.com/witt3rd/oh-my-hermes/issues/11). Roles will be added as lived rounds surface real tensions that the current set cannot represent. The discipline here is *learn through use, then expand* — the inverse of authoring all five roles up-front against imagined friction.
 
 ## When to Use
 

--- a/plugins/omh/skills/omh-triage/references/orchestrator-review-template.md
+++ b/plugins/omh/skills/omh-triage/references/orchestrator-review-template.md
@@ -1,0 +1,71 @@
+# Orchestrator review template
+
+Used at the Phase-2 → Phase-3 gate. The orchestrator (you) reviews the
+distilled output before any closures, recasts, or board updates execute.
+
+This is **your bar applied honestly**. If the run produced more
+ceremony than rigor — say so. Don't push verdicts to the user that
+you don't believe yourself. (See `omh-ralplan-orchestration` P25.)
+
+---
+
+```markdown
+# Orchestrator review — <YYYY-MM-DD> triage run
+
+## What was run
+
+- Backlog: <N> open issues at start
+- Roles: <Maintainer, Skeptic>
+- Phases completed: 0 (context), 1 (role passes), 2 (distillation)
+- Phase 3 (execution) GATED on this review
+
+## Verdict on the run itself
+
+- **Quality of Maintainer pass:** <strong / mixed / weak — with reasoning>
+- **Quality of Skeptic pass:** <strong / mixed / weak — with reasoning>
+- **Distillation conflicts:** <N — each enumerable>
+- **Confidence in the proposed closures:** <high / mixed / low>
+
+## What I'm proposing to execute
+
+- **Closures:** <list — each with one-line reason>
+- **Recasts:** <list — each with body-surgery summary>
+- **Refile-smaller:** <list — each with new-form summary>
+- **Project board updates:** <list>
+
+## What I'm NOT executing yet
+
+- **Conflicts requiring your decision:** <list — each framed as a
+  specific question>
+- **Recasts where I'm not confident in the new body:** <list>
+
+## Lessons I'd fold into the skill if you agree
+
+<L1, L2, ... — observations from this run that may want patching
+into omh-triage / omh-triage-orchestration / host PROCESS.md.>
+
+## My honest assessment
+
+<One paragraph: did this run actually need the multi-role consensus
+shape, or would a single-perspective walk have produced the same
+verdicts? If single-perspective would have worked, name what the
+multi-role pass added; if it added nothing, that's a lesson for
+the skill (T6 — running too often or under-pressing roles).>
+
+## Approval requested
+
+- [ ] Execute proposed closures
+- [ ] Execute proposed recasts
+- [ ] Execute proposed refile-smaller
+- [ ] Execute proposed board updates
+- [ ] Decisions on the N conflicts: <answers>
+
+⚒️ <orchestrator>
+- YYYY-MM-DD
+```
+
+The honesty discipline is load-bearing: if you find yourself writing
+"the loop surfaced some interesting questions" or "the user may want
+to weigh in on..." for everything — both are signals that you've
+dropped to the loop's altitude. Read `omh-ralplan-orchestration` P25
+for the full treatment.

--- a/plugins/omh/skills/omh-triage/references/triage-doc-template.md
+++ b/plugins/omh/skills/omh-triage/references/triage-doc-template.md
@@ -1,0 +1,78 @@
+# Triage doc template
+
+Structure for the dated round doc written under
+`<host-repo>/docs/triage/YYYY-MM-DD-<descriptor>.md`.
+
+Adapt to the host project's existing docs style. The 2026-04-29
+janus rewrite (`witt3rd/janus:docs/triage/2026-04-29-issue-triage.md`)
+is the canonical structural example.
+
+---
+
+```markdown
+# <Repo> open-issue triage — YYYY-MM-DD
+
+Carved by <author> at <user>'s request via `omh-triage` (v0.1).
+Ground-truth anchored to repo HEAD `<commit-ref>`.
+
+## Headline finding
+
+<N filed → X stale, Y recast, Z still-live.>
+<What's changed since the last pass.>
+
+## Run shape
+
+- Inventory: <N open at start>
+- Roles dispatched: <Maintainer, Skeptic>
+- Conflicts surfaced: <count, each named>
+- Time wall-clock: <duration>
+
+## Cluster-by-cluster vet
+
+<Per-cluster table: # / status / action.>
+
+## Verdicts
+
+### Closures (<N>)
+
+<Table: issue # / title / Maintainer verdict / pointer-comment summary.>
+
+### Recasts (<N>)
+
+<Table: issue # / title / body-surgery spec.>
+
+### Live (<N>)
+
+<Brief table: issue # / why it earned its slot per Skeptic.>
+
+### Conflicts escalated to user (<N>)
+
+<For each: Maintainer says X for reason A; Skeptic says Y for reason B;
+recommended resolution; user's decision.>
+
+## Project board updates
+
+<What moved on the project: target version reassignments, cluster
+changes, status updates.>
+
+## Tidying moves applied
+
+<Labels added, cross-links posted, label-creation done.>
+
+## What this pass did not do
+
+<Deferred to next round, with reasoning.>
+
+## Lessons surfaced
+
+<L1, L2, ... — what this round taught about the discipline. Candidates
+for folding into PROCESS.md or omh-triage SKILL.md after rounds 2+
+confirm them.>
+
+## Methodology note
+
+<What this pass anchored against; what the next pass should learn.>
+
+⚒️ <author>
+- YYYY-MM-DD: <round descriptor>
+```


### PR DESCRIPTION
## Summary

Ships **omh-triage v0.1** — a multi-role consensus skill for grooming an issue backlog. Modeled on `omh-ralplan` (Planner / Architect / Critic → consensus); applies multi-role pressure to the *triage* problem instead of the *planning* problem.

Closes the v0.1 portion of #9. Next milestone (Operator role, version-cut planning pressure) tracked at #11.

## What lands

### `plugins/omh/skills/omh-triage/`

The worker skill. Four phases:

- **Phase 0** — ground-truth pre-flight (repo HEAD + recent migrations + issue inventory + project board state + prior triage doc)
- **Phase 1** — role passes (Maintainer first, Skeptic second on Maintainer's live + recast output)
- **Phase 2** — orchestrator distillation via verdict-combination matrix
- **Phase 3** — user-gated execution

Six numbered pitfalls (T1–T6), including T6 which deliberately warns against shipping the missing roles up-front before lived rounds surface real tensions for them.

### `plugins/omh/skills/omh-triage-orchestration/`

Dispatcher's playbook. Pre-flight discipline (backlog audit, trigger audit, host-project-discipline audit), per-phase responsibilities, six pitfalls covering failure modes a triage dispatcher repeatedly hits. Mirrors `omh-ralplan-orchestration`.

### `plugins/omh/references/role-triage-maintainer.md`

Code-anchored ground-truth pressure. Per-issue verdicts: stale / recast / live / partial-stale / out-of-scope. Every verdict must cite a commit ref, file:line, or test name. The Maintainer is what catches dispatcher misreads — the role read the code; the dispatcher had only the labels.

### `plugins/omh/references/role-triage-skeptic.md`

Pruning pressure. Five skeptical techniques: recurrence, consolidation, smaller-form, inversion, filed-because-easy. Verdicts: keep / drop / dedup / refile-smaller / wait-for-recurrence. Default-to-drop discipline; lived-friction tag overrides default.

### `plugins/omh/skills/omh-triage/references/`

Two templates the orchestrator writes against:

- `triage-doc-template.md` — structure for the dated round doc under `<host-repo>/docs/triage/YYYY-MM-DD-*.md`
- `orchestrator-review-template.md` — pre-execution review where the orchestrator applies their own bar before user approval (cross-references `omh-ralplan-orchestration` P25 — skepticism over deference)

### `CONTRIBUTING.md` — proxy-pattern documentation

Documents the per-machine proxy-symlink pattern for testing pre-merge OMH changes from a worktree without touching `master`. The pattern:

```
~/.local/share/omh-dev/{plugin,skills}     ← proxy (flip this)
                ↑
profile <plugins,skills>/omh links here    ← never edited after setup
```

Why this matters: OMH ships to real users. Treating `master` as a place to "experiment" or "try this and see if it works" risks breaking installs in the wild. The proxy pattern lets you battle-test arbitrary worktrees from a live session without ever touching `master`'s tip until the work is baked. Includes the relative-vs-absolute path discipline for cross-machine portable profiles.

## Lived-evidence anchor

This is not a skill authored against imagined friction. It was battle-tested before this PR opened.

The actual run: [`witt3rd/janus` round 2 triage](https://github.com/witt3rd/janus/blob/main/docs/triage/2026-04-29-grooming-round-2.md). 25 open issues at start. The skill drove Phase 0 → Maintainer pass → Skeptic pass → orchestrator distillation → user gate → execution. Output:

- 14 closures (every one with a substantive pointer-comment citing a commit ref)
- 2 spinout issues from a decomposition surfaced mid-round
- 1 new repo (`witt3rd/janus-commons`) created as the named target of a mechanism that emerged from the Skeptic's pruning pressure
- Queue at end: **13 open** (down from 25)

The skill held end-to-end. No rule felt forced or skipped.

## Lessons surfaced from the lived run

Recorded in the [round 2 doc](https://github.com/witt3rd/janus/blob/main/docs/triage/2026-04-29-grooming-round-2.md) for fold-back into the skill after rounds 3+ confirm them:

- **L4 — Phase 0 quality determines run quality.** The Maintainer didn't waste a single tool call rederiving migrations because Phase 0 had already mapped them. T1 in `omh-triage-orchestration` is correct; worth promoting to a stronger gate.
- **L5 — Zero-conflict round = signal to add roles.** Round 2's verdict matrix produced zero escalations. Either the role pressures are aligned (this round) or the role set is too narrow (after multiple rounds). After two rounds of zero conflicts: ship Operator. **This is what #11 (v0.2) tracks.**
- **L6 — Skeptic's Backlog-column read.** The Skeptic's pruning concentrated heavily on the project's "Backlog" column. The column itself signals "deferred indefinitely"; Skeptic should default-skeptical on Backlog cards specifically.
- **L7 — Maintainer catches dispatcher's misreads (positive pattern).** Worth encoding as a positive pitfall: trust the role's reading over the dispatcher's pre-vet — the role just did the reading; the dispatcher hasn't.
- **L8 — When an umbrella issue lists N sub-symptoms, walk each.** Saves "drop" verdicts that should have been "resolved" with sub-symptom-by-sub-symptom pointer.

These haven't been folded into the skill yet. They're hypotheses pending round-3+ confirmation, exactly as the v0.1 framing intends.

## Honest assessment

The multi-role pass added real value on round 2 but **not enormous value**. A single-perspective walk would have closed maybe 10 instead of 14, missed the smaller-form refile pattern entirely, and missed the dedup. The Maintainer's correction on issues the dispatcher pre-classified incorrectly is exactly the dispatcher-misread-catch the skill is designed for.

The real test for the multi-role consensus shape is the round where Operator vs Skeptic pressure genuinely fight on version-cut placement. v0.1 isn't ready for that; v0.2 (Operator) is. That's why #11 is the next milestone, not "ship more roles up-front."

## Test plan

The skill is framework-shape (Markdown SKILL.md + role prompts), not Python; no automated tests added. The lived round is the test.

For future roles (Operator etc.), tests should verify:
- Role catalog discovery (`omh_roles.py:get_role_catalog()` finds new role files)
- Verdict-combination matrix expansion
- Conflict surfacing when 3+ roles disagree

These belong in #11's PR, not this one.

## Out of scope

- Operator / Architect / Member-advocate roles (#11 and follow-ons)
- Non-GitHub backlog support
- Multi-repo cross-project triage
- Smart conflict-resolution beyond escalate-to-user

## Closes

- Closes the v0.1 milestone of #9 (full role-set hypothesis stays open as the umbrella)
- v0.2 next-milestone tracked at #11
- Provenance for the proxy-pattern documentation: surfaced during the witt3rd/janus round 2 work

⚒️ Forge
