### PR TITLE
omh-ralplan-orchestration: brief-as-delivery + deep-review-as-archive (P26)

### DIFF
--- a/plugins/omh/skills/omh-ralplan-orchestration/SKILL.md
+++ b/plugins/omh/skills/omh-ralplan-orchestration/SKILL.md
@@ -7,7 +7,7 @@ description: >
   half this skill: the META question, seeded contests, required
   reading discipline, and pre-flight pitfalls are what make the loop
   produce truth instead of internal consistency.
-version: 1.0.0
+version: 1.1.0
 metadata:
   hermes:
     tags: [planning, ralplan, orchestration, multi-agent, consensus]
@@ -175,8 +175,26 @@ short summary — grep-able, survives session rotation.
 ### 5. Orchestrator review, then bring to user
 
 The orchestrator's own review is the final gate before the user sees
-anything. Write it as `<orchestrator>-review.md` (e.g. `forge-review.md`,
-or domain-appropriate name). Say:
+anything. **Write two artifacts**, not one:
+
+- **`brief.md`** — what the user reads. Decisions-first. ~1–2 pages.
+  Resolved decisions on top, deviations from pre-dispatch
+  conversation named, where the design landed in one paragraph,
+  open questions left, next steps. The user must be able to **give
+  judgment** from this alone — never force them to read the deep
+  review just to know what to decide.
+
+- **`<orchestrator>-review-deep.md`** — the archive. Internal chatter,
+  full reasoning, deference tests, run-method observations,
+  altitude addendum, what-the-Critic-caught-narratively. Lives on
+  disk for archaeology and for the rare moment the user wants the
+  full lens. **Default-not-read.** Replaces what older runs called
+  `<orchestrator>-review.md`.
+
+The brief is for delivery; the deep review is for the record. Treat
+them as different artifacts with different readers.
+
+What the deep review carries (same as before):
 
 - Does this meet my bar? (Yes/no + why.)
 - What the Critic caught that surprised me.
@@ -185,14 +203,27 @@ or domain-appropriate name). Say:
 - Where I predict the user will push back — give them priming
   before they read.
 - What this run taught me about the method.
+- Provisos folded during distillation (if any).
 
-If the review is weak, run another round or strengthen the principles.
-**Do not hand the user output below your own bar** — the altitude
-compact depends on this.
+What the brief carries (decisions-first, see P26 + template):
 
-See `references/orchestrator-review-template.md` for the full template.
+- Decisions you need from the user, numbered, with my-take on each.
+- Where I deviated from pre-dispatch conversation (be specific).
+- One-paragraph "where the design landed."
+- Open questions left for v2 / lived friction.
+- Next steps.
 
-## Pitfalls (numbered P1–P24)
+If the deep review is weak, run another round or strengthen the
+principles. **Do not hand the user output below your own bar** —
+the altitude compact depends on this. The brief is what tests the
+compact: if you cannot reduce the deep review to a clean
+decisions-first brief, you do not have the altitude you think you
+have.
+
+See `references/orchestrator-review-template.md` for the deep-review
+template and `references/brief-template.md` for the brief template.
+
+## Pitfalls (numbered P1–P26)
 
 These are the failure modes that orchestrators repeatedly stumble
 into. Each was learned the hard way. Numbering is contiguous; there
@@ -731,9 +762,10 @@ stance).
    exist? A cross-cutting stance? Sibling stances that overlap?
 
 2. **For each parent stance, check its vetting state.** Was it vetted
-   synchronously with the user (an `<orchestrator>-review.md` exists
-   AND was discussed)? Or does `plan.md` / equivalent forward-view
-   doc list a "vet this stance" gate that has not yet fired?
+   synchronously with the user (an `<orchestrator>-review-deep.md`
+   exists AND a `brief.md` was discussed)? Or does `plan.md` /
+   equivalent forward-view doc list a "vet this stance" gate that
+   has not yet fired?
 
 3. **For each parent stance, walk its positions against this
    session's reshapes.** Specifically: any user-named reframes from
@@ -918,6 +950,86 @@ it is the role. Surfacing every catch to the user as a question
 inverts the role into "subagent to user" — which is exactly the
 turn-by-turn correction loop ralplan was built to avoid (P24).
 
+### P26 — Deliver decisions-first; deep review is for the archive
+
+The orchestrator's deep review (`<orchestrator>-review-deep.md` —
+see step 5) is comprehensive: round tally, what-the-Critic-caught,
+where-I-push-back, where-I-think-the-user-will-push-back, what-this-
+run-proved-about-the-method, altitude addendum. It is honest. It is
+also **the wrong artifact to hand the user when you need a decision.**
+
+The failure mode this pitfall names: the orchestrator writes a
+strong deep review, the user reads it, and the user reports being
+"comprehensive and dense, yet oddly terse... I read a lot of this
+detail and am somewhat lost and dissociated. I really need you to
+bring me back a set of decisions you need me to make, even if
+agreement on something that was different from what we discussed
+and why."
+
+Translation: the deep review surfaces internal chatter the user
+already trusted you to handle. It demands the user re-traverse
+reasoning the loop already collapsed. It conflates *show your work*
+(which the deep review does) with *give me what I need to give
+judgment* (which is a different artifact). An executive presented
+with the deep review cannot give judgment from it; an executive
+presented with a brief can.
+
+Discipline:
+
+1. **Two artifacts at the orchestrator-review step, not one.** Deep
+   review for the archive (preserves provenance and your honest
+   self-assessment). Brief for delivery. Step 5 of the playbook
+   spells out both; honor it.
+
+2. **Decisions-first in the brief.** Lead with the decisions the
+   user needs to make, numbered. For each decision, state your-take
+   *and* the alternative. The user can scan, decide, return — they
+   should not need to read the deep review to know what they are
+   deciding.
+
+3. **Name deviations from pre-dispatch conversation explicitly.**
+   The user spent effort working through big rocks, nuances, and
+   considerations with you up-front. If the loop produced something
+   different from what you discussed, **say so in the brief** with
+   why. Hidden deviations corrode trust faster than admitted ones.
+
+4. **Where the design landed in one paragraph, not eight.** The deep
+   review's "where the stance ended up" 5–8 paragraph treatment
+   belongs in the deep review. The brief gets one paragraph that a
+   reader can hold in working memory while deciding.
+
+5. **Open questions and next steps belong in the brief.** They are
+   user-actionable. The internal chatter (deference tests,
+   altitude observations, pitfall-naming for the skill) belongs
+   only in the deep review.
+
+6. **The brief is the test of altitude.** If you cannot reduce the
+   deep review to a clean decisions-first brief, **you do not have
+   the altitude you think you have.** Write the brief; if it
+   sprawls, that is a signal — not to ship a longer brief, but to
+   re-run the distillation pass on the *deep review* until the
+   brief lands clean.
+
+7. **When the user reads only the brief, that is the success
+   condition, not the failure mode.** Many runs the user will
+   never read the deep review. That is correct. The deep review
+   is provenance; the brief is delivery.
+
+Field signal that this pitfall just fired: the user reads what you
+delivered and reports being lost / dissociated / unable to give
+judgment. **Do not respond by adding more to the deep review.**
+Respond by extracting a brief from it and patching the skill so
+future runs default to brief-as-delivery.
+
+See `references/brief-template.md` for the structural template.
+
+This pitfall also fixes a definitional ambiguity earlier sections
+(P19, the orchestrator-review template) carried: when those
+sections say "the orchestrator review," they mean the deep review
+(`<orchestrator>-review-deep.md`). Provisos still get folded in
+the deep review's distillation section; the brief simply doesn't
+need to surface them unless one of them rises to a user-decision.
+
 ## Template for the delegate_task goal
 
 ```
@@ -971,7 +1083,8 @@ docs/design/<domain>/
 ├── review-architect-v2.md   ← Round 2
 ├── review-critic-v2.md      ← Round 2
 ├── stance.md                ← distilled from v2; canonical user-read
-├── <orchestrator>-review.md ← orchestrator's final assessment
+├── brief.md                      ← decisions-first, what the user reads
+├── <orchestrator>-review-deep.md ← orchestrator's archive deep review
 └── (later) implementation-plan.md
 ```
 
@@ -1061,3 +1174,15 @@ verify external premises, settle filesystem layout, walk it with the
 user, kill phantom contests on reframe. Most pitfalls in this skill
 are pre-dispatch failures. Treat the package as the load-bearing
 artifact it is.
+
+Fifth: **decisions-first delivery, deep review for the archive.**
+At the orchestrator-review step, write two artifacts: `brief.md`
+(what the user reads to give judgment, decisions-first, ~1 page)
+and `<orchestrator>-review-deep.md` (provenance, internal chatter,
+the honest self-assessment). The user must be able to give judgment
+from the brief alone — never make them traverse the deep review
+just to know what to decide. P26 names this and the failure mode
+(handing the comprehensive deep review when an executive-style
+brief was needed). The brief is the test of altitude: if you cannot
+distill the deep review into a clean decisions-first brief, you do
+not have the altitude you think you have.

--- a/plugins/omh/skills/omh-ralplan-orchestration/SKILL.md
+++ b/plugins/omh/skills/omh-ralplan-orchestration/SKILL.md
@@ -954,9 +954,10 @@ turn-by-turn correction loop ralplan was built to avoid (P24).
 
 The orchestrator's deep review (`<orchestrator>-review-deep.md` —
 see step 5) is comprehensive: round tally, what-the-Critic-caught,
-where-I-push-back, where-I-think-the-user-will-push-back, what-this-
-run-proved-about-the-method, altitude addendum. It is honest. It is
-also **the wrong artifact to hand the user when you need a decision.**
+where-I-push-back, where-I-think-the-user-will-push-back,
+what-this-run-proved-about-the-method, altitude addendum. It is
+honest. It is also **the wrong artifact to hand the user when you
+need a decision.**
 
 The failure mode this pitfall names: the orchestrator writes a
 strong deep review, the user reads it, and the user reports being
@@ -1116,8 +1117,10 @@ interrupted, the next session reads this and resumes.
 - Canonical `stance.md` (or `requirements.md`) written, free of
   reviewer-scaffolding.
 - `.omh/plans/<file>.md` consensus summary written.
-- `<orchestrator>-review.md` written — honest, specific, not
-  performative.
+- `<orchestrator>-review-deep.md` written — honest, specific, not
+  performative (the archive / provenance artifact).
+- `brief.md` written — decisions-first, ~1 page, what the user
+  reads to give judgment (P26).
 - Single commit capturing the domain artifacts + state gitignore.
 - Commit message names: what the Critic caught, key positions
   landed, MV ready to execute on user sign-off.

--- a/plugins/omh/skills/omh-ralplan-orchestration/references/brief-template.md
+++ b/plugins/omh/skills/omh-ralplan-orchestration/references/brief-template.md
@@ -1,0 +1,162 @@
+# Brief template
+
+Used as `brief.md` at the orchestrator-review step (step 5 of the
+playbook). The brief is **what the user reads to give judgment**;
+the deep review (`<orchestrator>-review-deep.md`) is the archive.
+
+The brief must let an executive scan, decide, and return — without
+ever needing to read the deep review.
+
+See P26 for why this artifact exists separately from the deep
+review, and the failure mode it prevents.
+
+## Length
+
+~1–2 pages typical. ~400–800 words. If under 200, you skipped
+something the user actually needs to decide. If over 1500, you are
+shipping the deep review with a different filename — re-distill.
+
+## Structure
+
+```markdown
+# Brief — <domain> ralplan
+
+**For:** <user>
+**From:** <orchestrator>
+**Date:** <date>
+**Deep version:** `<orchestrator>-review-deep.md` (archive — internal chatter, full reasoning, deference tests, etc.)
+**Canonical artifacts:** `stance.md`, `<companion-artifact-1>.md`, ...
+
+---
+
+## What this is
+
+<2–4 sentences. Round tally compressed. The headline outcome of the run.
+What was avoided, what was caught, what landed.>
+
+## Decisions you need from me
+
+<Numbered list. Each decision:
+1. **<Decision name>** — <one-sentence framing of the choice>.
+   <My take + the alternative.>
+>
+
+(If decisions were already resolved in conversation before this brief
+was written, retitle this section "Decisions you needed to make
+(resolved)" and list how each was settled. Treat it as a record so
+the user can sanity-check.)
+
+## Where we deviated from pre-dispatch conversation
+
+<Be specific. Name each place the loop produced something different
+from what you and the user worked through up-front, and why.
+
+If there are no deviations, say so explicitly: "All positions align
+with what we worked through pre-dispatch." This is a load-bearing
+sentence — it tells the user nothing is hiding.>
+
+## What changed since the deep review (if applicable)
+
+<Only present if user feedback after the deep review drove patches
+to the canonical artifacts. List concrete changes:
+- File X: <change>
+- File Y: <change>
+
+If the brief is being delivered fresh after distillation with no
+post-deep-review changes, omit this section.>
+
+## Where the design landed (one paragraph)
+
+<Single paragraph, ~80–150 words. The shape of the design at a level
+the user can hold in working memory. Names the load-bearing positions
+without enumerating every dimension.>
+
+## Open questions left for v2 / lived friction
+
+<Bullets, ~3–6 items. Things that are NOT decided here, that the user
+should know are deferred. Distinguish "deferred to v2" from "owed
+follow-up" if that matters.>
+
+## Next steps
+
+<Numbered list, ~3–5 items. What happens after the user signs off.
+Who owns each. The sequence.>
+
+⚒️  (or your signature)
+```
+
+## What makes a brief honest vs performative
+
+**Honest:**
+- Decisions stated as decisions, with the alternative named so the
+  user can weigh
+- Deviations from pre-dispatch conversation explicit, with cause
+- One paragraph for the design shape, not five
+- Open questions named even when uncomfortable
+- Concrete next steps with ownership
+
+**Performative:**
+- "Comprehensive consensus reached" language without naming what
+  the user must decide
+- Hidden deviations (the loop went somewhere different and you hope
+  the user doesn't notice)
+- Five paragraphs on "where the stance ended up" because you
+  couldn't compress
+- Open questions buried in the deep review only
+- "Ready for your read" with no decisions named — the user reads,
+  finds nothing actionable, and disengages
+
+## The deviation discipline
+
+The most load-bearing section is **"Where we deviated from pre-dispatch
+conversation."** The user spent real cognitive effort working through
+the design with you before dispatch. Hidden deviations corrode trust
+the fastest. Surface them, name why, let the user push back. They
+will respect the deviation if you named it; they will be hurt if
+they discover it.
+
+If there were no deviations, say "All positions align with what we
+worked through pre-dispatch" explicitly. The absence-of-deviation
+sentence is itself load-bearing — it tells the user nothing is
+hiding.
+
+## The decision-stating discipline
+
+Every decision in the "Decisions you need from me" section must
+include:
+
+- **What's at stake** — one sentence framing the choice.
+- **My take** — your recommendation, named clearly.
+- **The alternative** — what saying no looks like, so the user can
+  weigh.
+
+Bad: "We need to decide on the trigger model."
+Good: "**Trigger model.** LLM call on every synthesis trigger, or
+deterministic-at-periodic with LLM only at session-start/shockwave?
+*My take: LLM-everywhere v1, telemetry watches the cost, fall back if
+it bites.* The architecture supports either; this is a v1 budget
+choice, not a structural one."
+
+The user can read the bad version and have no idea what to decide.
+The user can read the good version and decide in 20 seconds.
+
+## When to include "Decisions you needed to make (resolved)"
+
+If the brief is being written *after* a conversation where decisions
+were already settled, retitle the section and list how each was
+resolved. This is a record-of-record for the user to sanity-check
+that you heard correctly. It is not redundant; it is verification.
+
+## One discipline: write the brief before the deep review when possible
+
+Counter-intuitively: the brief is harder to write than the deep
+review. The deep review is a discharge — you write what you saw.
+The brief is a distillation — you write what the user must see.
+
+If you cannot write a clean brief, you do not have the altitude you
+think you have. Run another distillation pass on the deep review
+until the brief lands clean.
+
+When time permits, draft the brief first. The decisions-first
+discipline forces you to identify what's actually at stake. The
+deep review then writes itself as the supporting record.

--- a/plugins/omh/skills/omh-ralplan-orchestration/references/brief-template.md
+++ b/plugins/omh/skills/omh-ralplan-orchestration/references/brief-template.md
@@ -36,10 +36,13 @@ What was avoided, what was caught, what landed.>
 
 ## Decisions you need from me
 
-<Numbered list. Each decision:
+<!-- Numbered list. Each decision:
 1. **<Decision name>** — <one-sentence framing of the choice>.
    <My take + the alternative.>
->
+-->
+1. **<Decision name>** — <one-sentence framing of the choice>.
+   *My take:* <recommendation>. *Alternative:* <what saying no looks like>.
+2. **<Decision name>** — ...
 
 (If decisions were already resolved in conversation before this brief
 was written, retitle this section "Decisions you needed to make

--- a/plugins/omh/skills/omh-ralplan-orchestration/references/orchestrator-review-template.md
+++ b/plugins/omh/skills/omh-ralplan-orchestration/references/orchestrator-review-template.md
@@ -1,20 +1,29 @@
-# Orchestrator review template
+# Orchestrator deep-review template
 
-Used when writing the orchestrator's final review (e.g.
-`<orchestrator>-review.md`) — the honest assessment of the ralplan
-output, before handing to the user.
+Used when writing the orchestrator's deep review (e.g.
+`<orchestrator>-review-deep.md`) — the honest assessment of the
+ralplan output that lives in the archive.
+
+**This is NOT what the user reads to give judgment.** That is the
+brief (`brief.md`, see `brief-template.md`). The deep review is
+the provenance: full reasoning, deference tests, internal chatter,
+altitude observations. It captures *what you saw*; the brief
+captures *what the user must see*. See P26 for why these are two
+artifacts, not one.
 
 This is the final quality gate. If what you write here feels weak,
 the stance is not ready. Run another round, strengthen principles,
-or fix the context package.
+or fix the context package. **Then** distill the brief from the
+deep review.
 
 ```markdown
-# <Orchestrator>'s review of the <domain> ralplan output
+# <Orchestrator>'s deep review of the <domain> ralplan output
 
-**For:** <user>, when you read.
+**For:** archive (and the user, if they want the full lens).
+**Brief delivered separately:** `brief.md` (decisions-first, ~1 page).
 **From:** <orchestrator>
 **Date:** <date>
-**Stance file:** <path to stance.md> (read this *after* these notes)
+**Stance file:** <path to stance.md>
 
 ---
 
@@ -30,8 +39,8 @@ naming of the moves that made the output good.>
 ## Where the stance ended up
 
 <5-8 paragraphs. The dimensions, the load-bearing positions, what
-was retired, the MV first shape. Enough that the user understands
-the shape without having to read stance.md first.>
+was retired, the MV first shape. Enough that someone reading only
+this review (skipping stance.md) understands the shape.>
 
 ## Where I push back, gently
 
@@ -60,10 +69,10 @@ Format:
 This keeps provenance honest: the stance is the consensus product,
 but this review records what was folded vs what was punted.>
 
-## Summary for your review
+## Summary for the archive
 
-<5-bullet summary. End with: "ready for your read." Or
-not-ready-and-why.>
+<5-bullet summary. End with the brief's location:
+"Brief delivered at brief.md.">
 
 ---
 
@@ -76,7 +85,7 @@ loop would have been, and the principles-as-guardrails worked." Note
 when this fires; it's the value the orchestrator exists to deliver.>
 ```
 
-## What makes a review honest vs performative
+## What makes a deep review honest vs performative
 
 **Honest:**
 - Names specific things the Critic caught that the orchestrator
@@ -98,11 +107,22 @@ when this fires; it's the value the orchestrator exists to deliver.>
 ~1500-3000 words typical. If under 1000, you didn't engage deeply.
 If over 5000, you are re-writing the stance; stop.
 
-## One discipline: read the stance twice before writing the review
+## One discipline: read the stance twice before writing the deep review
 
 First pass: does it meet the done-criteria in context.md?
 Second pass: what would a skeptical user ask first?
 
-The review is written against the second-pass mental state, not the
-first. Compliance-checking is the Architect's job; the orchestrator's
-review is about whether the work is *good*.
+The deep review is written against the second-pass mental state, not
+the first. Compliance-checking is the Architect's job; the
+orchestrator's deep review is about whether the work is *good*.
+
+## After the deep review: write the brief
+
+The deep review is for the archive. The brief
+(`references/brief-template.md`) is for the user. Do not skip the
+brief — handing the user the deep review when they need a decision
+is the P26 failure.
+
+If you cannot reduce the deep review to a clean decisions-first
+brief, you do not have the altitude you think you have. Re-distill
+the deep review until the brief lands clean.


### PR DESCRIPTION
Lived-friction patch to `omh-ralplan-orchestration` from a real ralplan run.

## What happened

After distillation on a context-engineering ralplan, I wrote a comprehensive ~3700-word `forge-review.md` and handed it to Donald expecting sign-off. He read it and reported:

> "comprehensive and dense, yet oddly terse... these still have a lot of surfacing of internal chatter. i spent a lot of time with you up-front working through the big rocks, some nuances, different considerations to ensure were made. I read a lot of this detail and am somewhat lost and disassociated. I really need you to bring me back a set of decisions you need me to make, even if agreement on something that was different from what we discussed and why. ... like, I would never present this to my executive for a decision I needed from them. it just isn't digestable, so I can't actually give you my judgment."

Translation: the orchestrator's deep review is the wrong artifact to hand the user when you need a decision. It surfaces internal chatter the user already trusted you to handle. It demands the user re-traverse reasoning the loop already collapsed. An executive presented with the deep review cannot give judgment.

## Changes

- **Step 5 of the playbook** now requires **two artifacts**: `brief.md` (what the user reads, decisions-first, ~1 page) and `<orchestrator>-review-deep.md` (provenance, internal chatter, full reasoning). Older runs called the latter `<orchestrator>-review.md`; the rename is deliberate — same artifact, clearer role.
- **New pitfall P26** names the failure mode and the discipline that prevents it. Pitfall heading updated to P1–P26.
- **New `references/brief-template.md`** — decisions-first structure with: decisions you need from me (numbered, with my-take + alternative), deviations from pre-dispatch conversation (load-bearing — hidden deviations corrode trust), where-the-design-landed in one paragraph, open questions, next steps.
- **`references/orchestrator-review-template.md`** retitled as the deep-review template, points at brief-template, clarifies its role as archive-not-delivery.
- **File-layout block** updated to show both artifacts.
- **P22** (parent-stance-vetting) updated to reference `<orchestrator>-review-deep.md` + `brief.md` as the synchronous-vetting markers.
- **\"Do-not-lose content\"** section gets a fifth item: decisions-first delivery is now load-bearing on par with the META question, prep-as-half-the-value, counter-proposals, and the orchestrator-bar.
- Bumped version to **1.1.0**.

## Field signal

Orchestrator hands the user a comprehensive review, user reports being lost / dissociated / unable to give judgment. The pitfall says: do not respond by adding more to the deep review. Extract a brief from it. Make brief-as-delivery the default for next time.

## Validation

This patch is being shipped *just before* another omh-ralplan-orchestration cycle starts, so the next dispatch can run against the patched skill. The lived-friction-to-skill-patch loop is the discipline working as designed.

⚒️ — Forge