### PR TITLE
plugin.yaml: conform to Hermes plugin guide manifest schema

### DIFF
--- a/plugins/omh/plugin.yaml
+++ b/plugins/omh/plugin.yaml
@@ -1,17 +1,13 @@
 name: omh
 version: "0.1.0"
 description: "Oh My Hermes — infrastructure layer for OMH skills (state management, evidence gathering, mode awareness)"
-entry_point: plugin
-requires_python: ">=3.10"
+author: Donald Thompson
 
-tools:
+provides_tools:
   - omh_state
   - omh_gather_evidence
 
-hooks:
+provides_hooks:
   - pre_llm_call
   - on_session_end
   - pre_tool_call
-
-dependencies:
-  - pyyaml  # required for config.yaml loading


### PR DESCRIPTION
## What

Conform `plugins/omh/plugin.yaml` to the Hermes plugin guide manifest schema. Zero behavior change.

## Audit findings

Audited the OMH plugin against:
- The build-a-plugin guide (`hermes-agent/website/docs/guides/build-a-hermes-plugin.md`)
- The actual manifest parser at `hermes_cli/plugins.py` L242, L1022–1023

Hermes reads `provides_tools` and `provides_hooks`. The previous `tools:` / `hooks:` keys were **silently ignored** — the plugin worked because Hermes discovers what gets registered at `register()` time, not from the manifest, but the manifest was inaccurate about what the plugin ships.

## Changes

- `tools:` → `provides_tools:`
- `hooks:` → `provides_hooks:`
- removed `entry_point:` (not in schema)
- removed `requires_python:` (not in schema — pip handles Python version via `pyproject.toml`)
- removed `dependencies:` (not in schema — `pyyaml` is already declared in `pyproject.toml` where pip can act on it)
- added `author:` per the guide's optional fields

## What this does NOT change

- `register(ctx)` signature
- Tool handlers (`omh_state_handler`, `omh_evidence_handler`)
- Hook callbacks (`pre_llm_call`, `on_session_end`, `pre_tool_call`)
- `_install_skills()` skill-copy behavior

## What's still open (separate concern, not in this PR)

The guide flags the `_install_skills()` `shutil.copytree` pattern as the **legacy** approach. The current recommendation is `ctx.register_skill(name, skill_md_path)` which namespaces skills as `omh:<skill-name>`, makes them read-only, and avoids collision with built-in skills. Migrating that is a user-visible change (skills would load as `omh:omh-ralplan` instead of bare `omh-ralplan`) and deserves a design discussion. Will file a separate issue if you'd like.

⚒️ Forge
