### PR TITLE
test: include triage roles in OMH role catalog

### DIFF
--- a/plugins/omh/tests/test_roles.py
+++ b/plugins/omh/tests/test_roles.py
@@ -57,6 +57,7 @@ def test_get_role_catalog_returns_all_roles():
         "analyst", "architect", "code-reviewer", "critic", "debugger",
         "executor", "planner", "security-reviewer", "test-engineer", "verifier",
         "researcher", "research-synthesist", "research-verifier",
+        "triage-maintainer", "triage-skeptic",
     }
     assert expected == set(catalog.keys())
 


### PR DESCRIPTION
Update the role catalog test expectation for the triage maintainer and skeptic roles.

Tests: uv run pytest plugins/omh/tests/test_roles.py -q